### PR TITLE
Add <header> and <main> tags

### DIFF
--- a/pages/languages/basic/index.xnode
+++ b/pages/languages/basic/index.xnode
@@ -1,46 +1,50 @@
 <content:page>
-	<content:heading>Basic</content:heading>
-	
-	<p>BASIC (Beginner's All-purpose Symbolic Instruction Code) is a simple <content:tt>dynamic</content:tt> <content:tt>imperative</content:tt> programming language developed in the 1960s.</p>
-	
-	<p>BASIC was developed by Microsoft into several platforms, including <content:tt>QBasic</content:tt> and <content:tt>Visual Basic</content:tt>. Visual Basic has <content:tt>object oriented</content:tt> features and includes a drag and drop user interface toolset. These tools are proprietary and generally only work on Microsoft Windows. Other dialects of BASIC exist for various platforms, such as <content:tt>REALbasic</content:tt>.</p>
-	
-	<h3>Example Code</h3>
-	
-	<p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
-	
-	<content:listing src="example.txt" brush="basic" />
-	
-	<h3>Why would I learn this language?</h3>
-	
-	<p>BASIC is a simple language which is easy to learn. It provides a simple set of semantic constructs and data types. There are many <content:tt>free software</content:tt> implementations, but unfortunately the most typically used implementation is proprietary (Microsoft Visual Basic).</p>
-	
-	<h2>Starting Points</h2>
+  <header>
+    <content:heading>Basic</content:heading>
 
-	<!-- http://www.thefreecountry.com/compilers/basic.shtml -->
+    <p>BASIC (Beginner's All-purpose Symbolic Instruction Code) is a simple <content:tt>dynamic</content:tt> <content:tt>imperative</content:tt> programming language developed in the 1960s.</p>
+  </header>
 
-	<dl class="resources">
-		<dt><a href="http://gambas.sourceforge.net/en/main.html">Gambas</a></dt>
-		<dd>Gambas is a full-featured object language and development environment built on a BASIC interpreter.</dd>
-		
-		<dt><a href="http://www.freebasic.net/">FreeBASIC</a></dt>
-		<dd>FreeBASIC is a completely free, open-source, 32-bit BASIC compiler with a large supportive community.</dd>
-		
-		<dt><a href="http://msdn.microsoft.com/en-us/vbasic/ms789086.aspx">Visual Basic Developer Center</a></dt>
-		<dd>Introduction to programming with Visual Basic, as well as many other more advanced topics.</dd>
+  <main>
+    <p>BASIC was developed by Microsoft into several platforms, including <content:tt>QBasic</content:tt> and <content:tt>Visual Basic</content:tt>. Visual Basic has <content:tt>object oriented</content:tt> features and includes a drag and drop user interface toolset. These tools are proprietary and generally only work on Microsoft Windows. Other dialects of BASIC exist for various platforms, such as <content:tt>REALbasic</content:tt>.</p>
 
-		<dt><a href="http://www.homeandlearn.co.uk/NET/vbNET.html">Visual Basic .NET Tutorials for Beginners</a></dt>
-		<dd>An introduction to programming for beginners.</dd>
-	</dl>
-	
-	<h2>Further Reading</h2>
-	
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/BASIC">Wikipedia: Basic</a></li>
-		<li><a href="http://en.wikipedia.org/wiki/Commodore_64">Wikipedia: Commodore 64</a></li>
-		<li><a href="http://en.wikipedia.org/wiki/QBasic">Wikipedia: QBasic</a></li>
-		<li><a href="http://en.wikipedia.org/wiki/Visual Basic">Wikipedia: Visual Basic</a></li>
-	</ul>
-	
-	<comments />
+    <h3>Example Code</h3>
+
+    <p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
+
+    <content:listing src="example.txt" brush="basic" />
+
+    <h3>Why would I learn this language?</h3>
+
+    <p>BASIC is a simple language which is easy to learn. It provides a simple set of semantic constructs and data types. There are many <content:tt>free software</content:tt> implementations, but unfortunately the most typically used implementation is proprietary (Microsoft Visual Basic).</p>
+
+    <h2>Starting Points</h2>
+
+    <!-- http://www.thefreecountry.com/compilers/basic.shtml -->
+
+    <dl class="resources">
+      <dt><a href="http://gambas.sourceforge.net/en/main.html">Gambas</a></dt>
+      <dd>Gambas is a full-featured object language and development environment built on a BASIC interpreter.</dd>
+
+      <dt><a href="http://www.freebasic.net/">FreeBASIC</a></dt>
+      <dd>FreeBASIC is a completely free, open-source, 32-bit BASIC compiler with a large supportive community.</dd>
+
+      <dt><a href="http://msdn.microsoft.com/en-us/vbasic/ms789086.aspx">Visual Basic Developer Center</a></dt>
+      <dd>Introduction to programming with Visual Basic, as well as many other more advanced topics.</dd>
+
+      <dt><a href="http://www.homeandlearn.co.uk/NET/vbNET.html">Visual Basic .NET Tutorials for Beginners</a></dt>
+      <dd>An introduction to programming for beginners.</dd>
+    </dl>
+
+    <h2>Further Reading</h2>
+
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/BASIC">Wikipedia: Basic</a></li>
+      <li><a href="http://en.wikipedia.org/wiki/Commodore_64">Wikipedia: Commodore 64</a></li>
+      <li><a href="http://en.wikipedia.org/wiki/QBasic">Wikipedia: QBasic</a></li>
+      <li><a href="http://en.wikipedia.org/wiki/Visual Basic">Wikipedia: Visual Basic</a></li>
+    </ul>
+
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/basic/index.xnode
+++ b/pages/languages/basic/index.xnode
@@ -8,13 +8,13 @@
   <main>
     <p>BASIC was developed by Microsoft into several platforms, including <content:tt>QBasic</content:tt> and <content:tt>Visual Basic</content:tt>. Visual Basic has <content:tt>object oriented</content:tt> features and includes a drag and drop user interface toolset. These tools are proprietary and generally only work on Microsoft Windows. Other dialects of BASIC exist for various platforms, such as <content:tt>REALbasic</content:tt>.</p>
 
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
 
     <content:listing src="example.txt" brush="basic" />
 
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>BASIC is a simple language which is easy to learn. It provides a simple set of semantic constructs and data types. There are many <content:tt>free software</content:tt> implementations, but unfortunately the most typically used implementation is proprietary (Microsoft Visual Basic).</p>
 

--- a/pages/languages/basic/index.xnode
+++ b/pages/languages/basic/index.xnode
@@ -1,50 +1,50 @@
 <content:page>
-  <header>
-    <content:heading>Basic</content:heading>
+	<header>
+		<content:heading>Basic</content:heading>
 
-    <p>BASIC (Beginner's All-purpose Symbolic Instruction Code) is a simple <content:tt>dynamic</content:tt> <content:tt>imperative</content:tt> programming language developed in the 1960s.</p>
-  </header>
+		<p>BASIC (Beginner's All-purpose Symbolic Instruction Code) is a simple <content:tt>dynamic</content:tt> <content:tt>imperative</content:tt> programming language developed in the 1960s.</p>
+	</header>
 
-  <main>
-    <p>BASIC was developed by Microsoft into several platforms, including <content:tt>QBasic</content:tt> and <content:tt>Visual Basic</content:tt>. Visual Basic has <content:tt>object oriented</content:tt> features and includes a drag and drop user interface toolset. These tools are proprietary and generally only work on Microsoft Windows. Other dialects of BASIC exist for various platforms, such as <content:tt>REALbasic</content:tt>.</p>
+	<main>
+		<p>BASIC was developed by Microsoft into several platforms, including <content:tt>QBasic</content:tt> and <content:tt>Visual Basic</content:tt>. Visual Basic has <content:tt>object oriented</content:tt> features and includes a drag and drop user interface toolset. These tools are proprietary and generally only work on Microsoft Windows. Other dialects of BASIC exist for various platforms, such as <content:tt>REALbasic</content:tt>.</p>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
+		<p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
 
-    <content:listing src="example.txt" brush="basic" />
+		<content:listing src="example.txt" brush="basic" />
 
-    <h2>Why would I learn this language?</h2>
+		<h2>Why would I learn this language?</h2>
 
-    <p>BASIC is a simple language which is easy to learn. It provides a simple set of semantic constructs and data types. There are many <content:tt>free software</content:tt> implementations, but unfortunately the most typically used implementation is proprietary (Microsoft Visual Basic).</p>
+		<p>BASIC is a simple language which is easy to learn. It provides a simple set of semantic constructs and data types. There are many <content:tt>free software</content:tt> implementations, but unfortunately the most typically used implementation is proprietary (Microsoft Visual Basic).</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <!-- http://www.thefreecountry.com/compilers/basic.shtml -->
+		<!-- http://www.thefreecountry.com/compilers/basic.shtml -->
 
-    <dl class="resources">
-      <dt><a href="http://gambas.sourceforge.net/en/main.html">Gambas</a></dt>
-      <dd>Gambas is a full-featured object language and development environment built on a BASIC interpreter.</dd>
+		<dl class="resources">
+			<dt><a href="http://gambas.sourceforge.net/en/main.html">Gambas</a></dt>
+			<dd>Gambas is a full-featured object language and development environment built on a BASIC interpreter.</dd>
 
-      <dt><a href="http://www.freebasic.net/">FreeBASIC</a></dt>
-      <dd>FreeBASIC is a completely free, open-source, 32-bit BASIC compiler with a large supportive community.</dd>
+			<dt><a href="http://www.freebasic.net/">FreeBASIC</a></dt>
+			<dd>FreeBASIC is a completely free, open-source, 32-bit BASIC compiler with a large supportive community.</dd>
 
-      <dt><a href="http://msdn.microsoft.com/en-us/vbasic/ms789086.aspx">Visual Basic Developer Center</a></dt>
-      <dd>Introduction to programming with Visual Basic, as well as many other more advanced topics.</dd>
+			<dt><a href="http://msdn.microsoft.com/en-us/vbasic/ms789086.aspx">Visual Basic Developer Center</a></dt>
+			<dd>Introduction to programming with Visual Basic, as well as many other more advanced topics.</dd>
 
-      <dt><a href="http://www.homeandlearn.co.uk/NET/vbNET.html">Visual Basic .NET Tutorials for Beginners</a></dt>
-      <dd>An introduction to programming for beginners.</dd>
-    </dl>
+			<dt><a href="http://www.homeandlearn.co.uk/NET/vbNET.html">Visual Basic .NET Tutorials for Beginners</a></dt>
+			<dd>An introduction to programming for beginners.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/BASIC">Wikipedia: Basic</a></li>
-      <li><a href="http://en.wikipedia.org/wiki/Commodore_64">Wikipedia: Commodore 64</a></li>
-      <li><a href="http://en.wikipedia.org/wiki/QBasic">Wikipedia: QBasic</a></li>
-      <li><a href="http://en.wikipedia.org/wiki/Visual Basic">Wikipedia: Visual Basic</a></li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/BASIC">Wikipedia: Basic</a></li>
+			<li><a href="http://en.wikipedia.org/wiki/Commodore_64">Wikipedia: Commodore 64</a></li>
+			<li><a href="http://en.wikipedia.org/wiki/QBasic">Wikipedia: QBasic</a></li>
+			<li><a href="http://en.wikipedia.org/wiki/Visual Basic">Wikipedia: Visual Basic</a></li>
+		</ul>
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/c-sharp/index.xnode
+++ b/pages/languages/c-sharp/index.xnode
@@ -1,38 +1,42 @@
 <content:page>
-	<content:heading>C#</content:heading>
-	
-	<p>C# was originally designed by Microsoft as an application development language and thus has many features in common with <a href="../java">Java</a>. It is now standardised and there are several implementations that run on a variety of platforms. C# is a <content:tt>statically typed</content:tt> <content:tt>imperative</content:tt> programming language with both <content:tt>functional</content:tt> and <content:tt>object oriented</content:tt> features.</p>
-	
-	<h3>Why would I learn this language?</h3>
-	
-	<p>C# is a modern, fully featured programming language. It is built on top of the CLR which provides a wide range of APIs from 3D graphics to databases.</p>
-	
-	<p>Specifically, using Mono.NET it is possible to develop cross-platform desktop applications, web applications and games.</p>
-	
-	<h3>Starting Points</h3>
-	
-	<dl class="resources">
-		<dt><a href="http://www.mono-project.com/Introduction_to_developing_with_Mono">Introduction to developing with Mono</a></dt>
-		<dd>A short guide to C# including a Hello World example.</dd>
-	</dl>
-	
-	<h3>Further Reading</h3>
-	
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/C_Sharp_(programming_language)">Wikipedia: C#</a></li>
-		<li><a href="http://en.wikipedia.org/wiki/Mono_(software)">Wikipedia: Mono</a></li>
-		<li><a href="http://unity3d.com/">Unity 3D</a></li>
-	</ul>
+  <header>
+    <content:heading>C#</content:heading>
 
-	<h3>Example Code</h3>
+    <p>C# was originally designed by Microsoft as an application development language and thus has many features in common with <a href="../java">Java</a>. It is now standardised and there are several implementations that run on a variety of platforms. C# is a <content:tt>statically typed</content:tt> <content:tt>imperative</content:tt> programming language with both <content:tt>functional</content:tt> and <content:tt>object oriented</content:tt> features.</p>
+  </header>
 
-	<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzcs">here</a>.</p>
+  <main>
+    <h3>Why would I learn this language?</h3>
 
-	<content:listing src="fizz-buzz-example.txt" brush="c-sharp" />
+    <p>C# is a modern, fully featured programming language. It is built on top of the CLR which provides a wide range of APIs from 3D graphics to databases.</p>
 
-	<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorscs">here</a>.</p>
+    <p>Specifically, using Mono.NET it is possible to develop cross-platform desktop applications, web applications and games.</p>
 
-	<content:listing src="100-doors-example.txt" brush="c-sharp" />
+    <h3>Starting Points</h3>
 
-	<comments />
+    <dl class="resources">
+      <dt><a href="http://www.mono-project.com/Introduction_to_developing_with_Mono">Introduction to developing with Mono</a></dt>
+      <dd>A short guide to C# including a Hello World example.</dd>
+    </dl>
+
+    <h3>Further Reading</h3>
+
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/C_Sharp_(programming_language)">Wikipedia: C#</a></li>
+      <li><a href="http://en.wikipedia.org/wiki/Mono_(software)">Wikipedia: Mono</a></li>
+      <li><a href="http://unity3d.com/">Unity 3D</a></li>
+    </ul>
+
+    <h3>Example Code</h3>
+
+    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzcs">here</a>.</p>
+
+    <content:listing src="fizz-buzz-example.txt" brush="c-sharp" />
+
+    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorscs">here</a>.</p>
+
+    <content:listing src="100-doors-example.txt" brush="c-sharp" />
+
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/c-sharp/index.xnode
+++ b/pages/languages/c-sharp/index.xnode
@@ -1,42 +1,42 @@
 <content:page>
-  <header>
-    <content:heading>C#</content:heading>
+	<header>
+		<content:heading>C#</content:heading>
 
-    <p>C# was originally designed by Microsoft as an application development language and thus has many features in common with <a href="../java">Java</a>. It is now standardised and there are several implementations that run on a variety of platforms. C# is a <content:tt>statically typed</content:tt> <content:tt>imperative</content:tt> programming language with both <content:tt>functional</content:tt> and <content:tt>object oriented</content:tt> features.</p>
-  </header>
+		<p>C# was originally designed by Microsoft as an application development language and thus has many features in common with <a href="../java">Java</a>. It is now standardised and there are several implementations that run on a variety of platforms. C# is a <content:tt>statically typed</content:tt> <content:tt>imperative</content:tt> programming language with both <content:tt>functional</content:tt> and <content:tt>object oriented</content:tt> features.</p>
+	</header>
 
-  <main>
-    <h2>Why would I learn this language?</h2>
+	<main>
+		<h2>Why would I learn this language?</h2>
 
-    <p>C# is a modern, fully featured programming language. It is built on top of the CLR which provides a wide range of APIs from 3D graphics to databases.</p>
+		<p>C# is a modern, fully featured programming language. It is built on top of the CLR which provides a wide range of APIs from 3D graphics to databases.</p>
 
-    <p>Specifically, using Mono.NET it is possible to develop cross-platform desktop applications, web applications and games.</p>
+		<p>Specifically, using Mono.NET it is possible to develop cross-platform desktop applications, web applications and games.</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://www.mono-project.com/Introduction_to_developing_with_Mono">Introduction to developing with Mono</a></dt>
-      <dd>A short guide to C# including a Hello World example.</dd>
-    </dl>
+		<dl class="resources">
+			<dt><a href="http://www.mono-project.com/Introduction_to_developing_with_Mono">Introduction to developing with Mono</a></dt>
+			<dd>A short guide to C# including a Hello World example.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/C_Sharp_(programming_language)">Wikipedia: C#</a></li>
-      <li><a href="http://en.wikipedia.org/wiki/Mono_(software)">Wikipedia: Mono</a></li>
-      <li><a href="http://unity3d.com/">Unity 3D</a></li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/C_Sharp_(programming_language)">Wikipedia: C#</a></li>
+			<li><a href="http://en.wikipedia.org/wiki/Mono_(software)">Wikipedia: Mono</a></li>
+			<li><a href="http://unity3d.com/">Unity 3D</a></li>
+		</ul>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzcs">here</a>.</p>
+		<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzcs">here</a>.</p>
 
-    <content:listing src="fizz-buzz-example.txt" brush="c-sharp" />
+		<content:listing src="fizz-buzz-example.txt" brush="c-sharp" />
 
-    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorscs">here</a>.</p>
+		<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorscs">here</a>.</p>
 
-    <content:listing src="100-doors-example.txt" brush="c-sharp" />
+		<content:listing src="100-doors-example.txt" brush="c-sharp" />
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/c-sharp/index.xnode
+++ b/pages/languages/c-sharp/index.xnode
@@ -6,20 +6,20 @@
   </header>
 
   <main>
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>C# is a modern, fully featured programming language. It is built on top of the CLR which provides a wide range of APIs from 3D graphics to databases.</p>
 
     <p>Specifically, using Mono.NET it is possible to develop cross-platform desktop applications, web applications and games.</p>
 
-    <h3>Starting Points</h3>
+    <h2>Starting Points</h2>
 
     <dl class="resources">
       <dt><a href="http://www.mono-project.com/Introduction_to_developing_with_Mono">Introduction to developing with Mono</a></dt>
       <dd>A short guide to C# including a Hello World example.</dd>
     </dl>
 
-    <h3>Further Reading</h3>
+    <h2>Further Reading</h2>
 
     <ul>
       <li><a href="http://en.wikipedia.org/wiki/C_Sharp_(programming_language)">Wikipedia: C#</a></li>
@@ -27,7 +27,7 @@
       <li><a href="http://unity3d.com/">Unity 3D</a></li>
     </ul>
 
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzcs">here</a>.</p>
 

--- a/pages/languages/c/index.xnode
+++ b/pages/languages/c/index.xnode
@@ -10,7 +10,7 @@
 
     <p>Many languages have been derived from C (either in terms of syntax or semantics), such as <content:tt to="cpp">C++</content:tt>, <content:tt>Objective-C</content:tt>, <content:tt>PHP</content:tt>, <content:tt>Java</content:tt> and <content:tt>Python</content:tt> to name a few.</p>
 
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>C is a low-level programming language which is useful for writing operating systems and embedded systems. It is often also used for application programming (including game development) and server programming due to its integration with the system and external libraries.</p>
 
@@ -20,7 +20,7 @@
 
     <p>For all its flaws, C is a popular language and is used throughout the industry, and its syntax is the basis for many other programming languages.</p>
 
-    <h3>Starting Points</h3>
+    <h2>Starting Points</h2>
 
     <dl class="resources">
       <dt><a href="http://cprog.tomsweb.net/cintro.html">An introduction to C</a></dt>
@@ -33,14 +33,14 @@
       <dd>An introduction to programming C for beginners.</dd>
     </dl>
 
-    <h3>Further Reading</h3>
+    <h2>Further Reading</h2>
 
     <ul>
       <li><a href="http://en.wikipedia.org/wiki/C_(programming_language)">Wikipedia: C</a></li>
       <li><a href="http://en.wikipedia.org/wiki/GNU_Compiler_Collection">Wikipedia: GNU Compiler Collection</a></li>
     </ul>
 
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzc">here</a>.</p>
 

--- a/pages/languages/c/index.xnode
+++ b/pages/languages/c/index.xnode
@@ -1,51 +1,55 @@
 <content:page>
-	<content:heading>C</content:heading>
-	
-	<p>C was developed in the early 1970s as a programming language for <content:tt>Unix</content:tt>. It is a <content:tt>statically typed</content:tt> <content:tt>imperative</content:tt> language that was designed to encourage machine-independent programming.</p>
-	
-	<p>C is generally <content:tt>compiled</content:tt> and compilers are widely available for many hardware platforms and operating systems. Because of this, it has become a baseline for programming in the modern computing environment.</p>
-	
-	<p>Many languages have been derived from C (either in terms of syntax or semantics), such as <content:tt to="cpp">C++</content:tt>, <content:tt>Objective-C</content:tt>, <content:tt>PHP</content:tt>, <content:tt>Java</content:tt> and <content:tt>Python</content:tt> to name a few.</p>
-	
-	<h3>Why would I learn this language?</h3>
-	
-	<p>C is a low-level programming language which is useful for writing operating systems and embedded systems. It is often also used for application programming (including game development) and server programming due to its integration with the system and external libraries.</p>
-	
-	<p>C syntax is generally simple, but its type system often makes source code complex and difficult to read and write.</p>
-	
-	<p>C is generally available for most platforms, however it is generally hard to write cross-platform applications without using advanced supporting tools.</p>
-	
-	<p>For all its flaws, C is a popular language and is used throughout the industry, and its syntax is the basis for many other programming languages.</p>
-	
-	<h3>Starting Points</h3>
-	
-	<dl class="resources">
-		<dt><a href="http://cprog.tomsweb.net/cintro.html">An introduction to C</a></dt>
-		<dd>An extensive tutorial covering many C features.</dd>
-		
-		<dt><a href="http://www.network-theory.co.uk/docs/gccintro/index.html">An Introduction to GCC</a></dt>
-		<dd>A manual that provides an introduction to the GNU C and C++ compilers.</dd>
-		
-		<dt><a href="http://beej.us/guide/bgc/">Beej's Guide to C Programming</a></dt>
-		<dd>An introduction to programming C for beginners.</dd>
-	</dl>
-	
-	<h3>Further Reading</h3>
-	
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/C_(programming_language)">Wikipedia: C</a></li>
-		<li><a href="http://en.wikipedia.org/wiki/GNU_Compiler_Collection">Wikipedia: GNU Compiler Collection</a></li>
-	</ul>
+  <header>
+    <content:heading>C</content:heading>
 
-	<h3>Example Code</h3>
+    <p>C was developed in the early 1970s as a programming language for <content:tt>Unix</content:tt>. It is a <content:tt>statically typed</content:tt> <content:tt>imperative</content:tt> language that was designed to encourage machine-independent programming.</p>
+  </header>
 
-	<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzc">here</a>.</p>
+  <main>
+    <p>C is generally <content:tt>compiled</content:tt> and compilers are widely available for many hardware platforms and operating systems. Because of this, it has become a baseline for programming in the modern computing environment.</p>
 
-	<content:listing src="fizz-buzz-example.txt" brush="clang" />
+    <p>Many languages have been derived from C (either in terms of syntax or semantics), such as <content:tt to="cpp">C++</content:tt>, <content:tt>Objective-C</content:tt>, <content:tt>PHP</content:tt>, <content:tt>Java</content:tt> and <content:tt>Python</content:tt> to name a few.</p>
 
-	<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsc">here</a>.</p>
-	
-	<content:listing src="100-doors-example.txt" brush="clang" />
+    <h3>Why would I learn this language?</h3>
 
-	<comments />
+    <p>C is a low-level programming language which is useful for writing operating systems and embedded systems. It is often also used for application programming (including game development) and server programming due to its integration with the system and external libraries.</p>
+
+    <p>C syntax is generally simple, but its type system often makes source code complex and difficult to read and write.</p>
+
+    <p>C is generally available for most platforms, however it is generally hard to write cross-platform applications without using advanced supporting tools.</p>
+
+    <p>For all its flaws, C is a popular language and is used throughout the industry, and its syntax is the basis for many other programming languages.</p>
+
+    <h3>Starting Points</h3>
+
+    <dl class="resources">
+      <dt><a href="http://cprog.tomsweb.net/cintro.html">An introduction to C</a></dt>
+      <dd>An extensive tutorial covering many C features.</dd>
+
+      <dt><a href="http://www.network-theory.co.uk/docs/gccintro/index.html">An Introduction to GCC</a></dt>
+      <dd>A manual that provides an introduction to the GNU C and C++ compilers.</dd>
+
+      <dt><a href="http://beej.us/guide/bgc/">Beej's Guide to C Programming</a></dt>
+      <dd>An introduction to programming C for beginners.</dd>
+    </dl>
+
+    <h3>Further Reading</h3>
+
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/C_(programming_language)">Wikipedia: C</a></li>
+      <li><a href="http://en.wikipedia.org/wiki/GNU_Compiler_Collection">Wikipedia: GNU Compiler Collection</a></li>
+    </ul>
+
+    <h3>Example Code</h3>
+
+    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzc">here</a>.</p>
+
+    <content:listing src="fizz-buzz-example.txt" brush="clang" />
+
+    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsc">here</a>.</p>
+
+    <content:listing src="100-doors-example.txt" brush="clang" />
+
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/c/index.xnode
+++ b/pages/languages/c/index.xnode
@@ -1,55 +1,55 @@
 <content:page>
-  <header>
-    <content:heading>C</content:heading>
+	<header>
+		<content:heading>C</content:heading>
 
-    <p>C was developed in the early 1970s as a programming language for <content:tt>Unix</content:tt>. It is a <content:tt>statically typed</content:tt> <content:tt>imperative</content:tt> language that was designed to encourage machine-independent programming.</p>
-  </header>
+		<p>C was developed in the early 1970s as a programming language for <content:tt>Unix</content:tt>. It is a <content:tt>statically typed</content:tt> <content:tt>imperative</content:tt> language that was designed to encourage machine-independent programming.</p>
+	</header>
 
-  <main>
-    <p>C is generally <content:tt>compiled</content:tt> and compilers are widely available for many hardware platforms and operating systems. Because of this, it has become a baseline for programming in the modern computing environment.</p>
+	<main>
+		<p>C is generally <content:tt>compiled</content:tt> and compilers are widely available for many hardware platforms and operating systems. Because of this, it has become a baseline for programming in the modern computing environment.</p>
 
-    <p>Many languages have been derived from C (either in terms of syntax or semantics), such as <content:tt to="cpp">C++</content:tt>, <content:tt>Objective-C</content:tt>, <content:tt>PHP</content:tt>, <content:tt>Java</content:tt> and <content:tt>Python</content:tt> to name a few.</p>
+		<p>Many languages have been derived from C (either in terms of syntax or semantics), such as <content:tt to="cpp">C++</content:tt>, <content:tt>Objective-C</content:tt>, <content:tt>PHP</content:tt>, <content:tt>Java</content:tt> and <content:tt>Python</content:tt> to name a few.</p>
 
-    <h2>Why would I learn this language?</h2>
+		<h2>Why would I learn this language?</h2>
 
-    <p>C is a low-level programming language which is useful for writing operating systems and embedded systems. It is often also used for application programming (including game development) and server programming due to its integration with the system and external libraries.</p>
+		<p>C is a low-level programming language which is useful for writing operating systems and embedded systems. It is often also used for application programming (including game development) and server programming due to its integration with the system and external libraries.</p>
 
-    <p>C syntax is generally simple, but its type system often makes source code complex and difficult to read and write.</p>
+		<p>C syntax is generally simple, but its type system often makes source code complex and difficult to read and write.</p>
 
-    <p>C is generally available for most platforms, however it is generally hard to write cross-platform applications without using advanced supporting tools.</p>
+		<p>C is generally available for most platforms, however it is generally hard to write cross-platform applications without using advanced supporting tools.</p>
 
-    <p>For all its flaws, C is a popular language and is used throughout the industry, and its syntax is the basis for many other programming languages.</p>
+		<p>For all its flaws, C is a popular language and is used throughout the industry, and its syntax is the basis for many other programming languages.</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://cprog.tomsweb.net/cintro.html">An introduction to C</a></dt>
-      <dd>An extensive tutorial covering many C features.</dd>
+		<dl class="resources">
+			<dt><a href="http://cprog.tomsweb.net/cintro.html">An introduction to C</a></dt>
+			<dd>An extensive tutorial covering many C features.</dd>
 
-      <dt><a href="http://www.network-theory.co.uk/docs/gccintro/index.html">An Introduction to GCC</a></dt>
-      <dd>A manual that provides an introduction to the GNU C and C++ compilers.</dd>
+			<dt><a href="http://www.network-theory.co.uk/docs/gccintro/index.html">An Introduction to GCC</a></dt>
+			<dd>A manual that provides an introduction to the GNU C and C++ compilers.</dd>
 
-      <dt><a href="http://beej.us/guide/bgc/">Beej's Guide to C Programming</a></dt>
-      <dd>An introduction to programming C for beginners.</dd>
-    </dl>
+			<dt><a href="http://beej.us/guide/bgc/">Beej's Guide to C Programming</a></dt>
+			<dd>An introduction to programming C for beginners.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/C_(programming_language)">Wikipedia: C</a></li>
-      <li><a href="http://en.wikipedia.org/wiki/GNU_Compiler_Collection">Wikipedia: GNU Compiler Collection</a></li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/C_(programming_language)">Wikipedia: C</a></li>
+			<li><a href="http://en.wikipedia.org/wiki/GNU_Compiler_Collection">Wikipedia: GNU Compiler Collection</a></li>
+		</ul>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzc">here</a>.</p>
+		<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzc">here</a>.</p>
 
-    <content:listing src="fizz-buzz-example.txt" brush="clang" />
+		<content:listing src="fizz-buzz-example.txt" brush="clang" />
 
-    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsc">here</a>.</p>
+		<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsc">here</a>.</p>
 
-    <content:listing src="100-doors-example.txt" brush="clang" />
+		<content:listing src="100-doors-example.txt" brush="clang" />
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/cpp/index.xnode
+++ b/pages/languages/cpp/index.xnode
@@ -8,7 +8,7 @@
   <main>
     <p>C++ is generally <content:tt>compiled</content:tt> and compilers exist for many platforms, however due to the complexity of the C++ standard, compilers don't always behave the same way.</p>
 
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>C++ is in some ways a super-set of <a href="../c">C</a>. It was originally called "C with Objects". It adds many advanced language features such as classes, namespaces, exceptions and meta-programming.</p>
 
@@ -16,7 +16,7 @@
 
     <p>C++ provides a useful level of abstraction and performance, and is used in both application development. The majority of computer games are written using C++.</p>
 
-    <h3>Starting Points</h3>
+    <h2>Starting Points</h2>
 
     <dl class="resources">
       <dt><a href="http://www.cplusplus.com/doc/tutorial/introduction/">C++ Language Tutorial</a></dt>
@@ -26,7 +26,7 @@
       <dd>A manual that provides an introduction to the GNU C and C++ compilers.</dd>
     </dl>
 
-    <h3>Further Reading</h3>
+    <h2>Further Reading</h2>
 
     <ul>
       <li><a href="http://en.wikipedia.org/wiki/C++">Wikipedia: C++</a></li>
@@ -34,7 +34,7 @@
       <li><a href="http://www.parashift.com/c%2B%2B-faq-lite/">C++ FAQ</a></li>
     </ul>
 
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzcpp">here</a>.</p>
 

--- a/pages/languages/cpp/index.xnode
+++ b/pages/languages/cpp/index.xnode
@@ -1,45 +1,49 @@
 <content:page>
-	<content:heading>C++</content:heading>
-	
-	<p>C++ was initially designed as an extension of C and adds <content:tt>object oriented</content:tt> and <content:tt>meta programming</content:tt> features. Like C it is a <content:tt>statically typed</content:tt> <content:tt>imperative</content:tt> language, but in addition it provides many high level features such as <content:tt>exceptions</content:tt> and libraries.</p>
-	
-	<p>C++ is generally <content:tt>compiled</content:tt> and compilers exist for many platforms, however due to the complexity of the C++ standard, compilers don't always behave the same way.</p>
+  <header>
+    <content:heading>C++</content:heading>
 
-	<h3>Why would I learn this language?</h3>
-	
-	<p>C++ is in some ways a super-set of <a href="../c">C</a>. It was originally called "C with Objects". It adds many advanced language features such as classes, namespaces, exceptions and meta-programming.</p>
-	
-	<p>C++ has many of the same issues as C, but it also adds many new issues (complex syntax and semantic behavior). On the whole, however, it is a useful language which is used in many different industries.</p>
-	
-	<p>C++ provides a useful level of abstraction and performance, and is used in both application development. The majority of computer games are written using C++.</p>
-	
-	<h3>Starting Points</h3>
+    <p>C++ was initially designed as an extension of C and adds <content:tt>object oriented</content:tt> and <content:tt>meta programming</content:tt> features. Like C it is a <content:tt>statically typed</content:tt> <content:tt>imperative</content:tt> language, but in addition it provides many high level features such as <content:tt>exceptions</content:tt> and libraries.</p>
+  </header>
 
-	<dl class="resources">
-		<dt><a href="http://www.cplusplus.com/doc/tutorial/introduction/">C++ Language Tutorial</a></dt>
-		<dd>A beginner guide to programming in C++.</dd>
+  <main>
+    <p>C++ is generally <content:tt>compiled</content:tt> and compilers exist for many platforms, however due to the complexity of the C++ standard, compilers don't always behave the same way.</p>
 
-		<dt><a href="http://www.network-theory.co.uk/docs/gccintro/index.html">An Introduction to GCC</a></dt>
-		<dd>A manual that provides an introduction to the GNU C and C++ compilers.</dd>
-	</dl>
-	
-	<h3>Further Reading</h3>
-	
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/C++">Wikipedia: C++</a></li>
-		<li><a href="http://en.wikipedia.org/wiki/GNU_Compiler_Collection">Wikipedia: GNU Compiler Collection</a></li>
-		<li><a href="http://www.parashift.com/c%2B%2B-faq-lite/">C++ FAQ</a></li>
-	</ul>
+    <h3>Why would I learn this language?</h3>
 
-	<h3>Example Code</h3>
+    <p>C++ is in some ways a super-set of <a href="../c">C</a>. It was originally called "C with Objects". It adds many advanced language features such as classes, namespaces, exceptions and meta-programming.</p>
 
-	<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzcpp">here</a>.</p>
+    <p>C++ has many of the same issues as C, but it also adds many new issues (complex syntax and semantic behavior). On the whole, however, it is a useful language which is used in many different industries.</p>
 
-	<content:listing src="fizz-buzz-example.txt" brush="clang" />
+    <p>C++ provides a useful level of abstraction and performance, and is used in both application development. The majority of computer games are written using C++.</p>
 
-	<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorscpp">here</a>.</p>
+    <h3>Starting Points</h3>
 
-	<content:listing src="100-doors-example.txt" brush="clang" />
-	
-	<comments />
+    <dl class="resources">
+      <dt><a href="http://www.cplusplus.com/doc/tutorial/introduction/">C++ Language Tutorial</a></dt>
+      <dd>A beginner guide to programming in C++.</dd>
+
+      <dt><a href="http://www.network-theory.co.uk/docs/gccintro/index.html">An Introduction to GCC</a></dt>
+      <dd>A manual that provides an introduction to the GNU C and C++ compilers.</dd>
+    </dl>
+
+    <h3>Further Reading</h3>
+
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/C++">Wikipedia: C++</a></li>
+      <li><a href="http://en.wikipedia.org/wiki/GNU_Compiler_Collection">Wikipedia: GNU Compiler Collection</a></li>
+      <li><a href="http://www.parashift.com/c%2B%2B-faq-lite/">C++ FAQ</a></li>
+    </ul>
+
+    <h3>Example Code</h3>
+
+    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzcpp">here</a>.</p>
+
+    <content:listing src="fizz-buzz-example.txt" brush="clang" />
+
+    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorscpp">here</a>.</p>
+
+    <content:listing src="100-doors-example.txt" brush="clang" />
+
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/cpp/index.xnode
+++ b/pages/languages/cpp/index.xnode
@@ -1,49 +1,49 @@
 <content:page>
-  <header>
-    <content:heading>C++</content:heading>
+	<header>
+		<content:heading>C++</content:heading>
 
-    <p>C++ was initially designed as an extension of C and adds <content:tt>object oriented</content:tt> and <content:tt>meta programming</content:tt> features. Like C it is a <content:tt>statically typed</content:tt> <content:tt>imperative</content:tt> language, but in addition it provides many high level features such as <content:tt>exceptions</content:tt> and libraries.</p>
-  </header>
+		<p>C++ was initially designed as an extension of C and adds <content:tt>object oriented</content:tt> and <content:tt>meta programming</content:tt> features. Like C it is a <content:tt>statically typed</content:tt> <content:tt>imperative</content:tt> language, but in addition it provides many high level features such as <content:tt>exceptions</content:tt> and libraries.</p>
+	</header>
 
-  <main>
-    <p>C++ is generally <content:tt>compiled</content:tt> and compilers exist for many platforms, however due to the complexity of the C++ standard, compilers don't always behave the same way.</p>
+	<main>
+		<p>C++ is generally <content:tt>compiled</content:tt> and compilers exist for many platforms, however due to the complexity of the C++ standard, compilers don't always behave the same way.</p>
 
-    <h2>Why would I learn this language?</h2>
+		<h2>Why would I learn this language?</h2>
 
-    <p>C++ is in some ways a super-set of <a href="../c">C</a>. It was originally called "C with Objects". It adds many advanced language features such as classes, namespaces, exceptions and meta-programming.</p>
+		<p>C++ is in some ways a super-set of <a href="../c">C</a>. It was originally called "C with Objects". It adds many advanced language features such as classes, namespaces, exceptions and meta-programming.</p>
 
-    <p>C++ has many of the same issues as C, but it also adds many new issues (complex syntax and semantic behavior). On the whole, however, it is a useful language which is used in many different industries.</p>
+		<p>C++ has many of the same issues as C, but it also adds many new issues (complex syntax and semantic behavior). On the whole, however, it is a useful language which is used in many different industries.</p>
 
-    <p>C++ provides a useful level of abstraction and performance, and is used in both application development. The majority of computer games are written using C++.</p>
+		<p>C++ provides a useful level of abstraction and performance, and is used in both application development. The majority of computer games are written using C++.</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://www.cplusplus.com/doc/tutorial/introduction/">C++ Language Tutorial</a></dt>
-      <dd>A beginner guide to programming in C++.</dd>
+		<dl class="resources">
+			<dt><a href="http://www.cplusplus.com/doc/tutorial/introduction/">C++ Language Tutorial</a></dt>
+			<dd>A beginner guide to programming in C++.</dd>
 
-      <dt><a href="http://www.network-theory.co.uk/docs/gccintro/index.html">An Introduction to GCC</a></dt>
-      <dd>A manual that provides an introduction to the GNU C and C++ compilers.</dd>
-    </dl>
+			<dt><a href="http://www.network-theory.co.uk/docs/gccintro/index.html">An Introduction to GCC</a></dt>
+			<dd>A manual that provides an introduction to the GNU C and C++ compilers.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/C++">Wikipedia: C++</a></li>
-      <li><a href="http://en.wikipedia.org/wiki/GNU_Compiler_Collection">Wikipedia: GNU Compiler Collection</a></li>
-      <li><a href="http://www.parashift.com/c%2B%2B-faq-lite/">C++ FAQ</a></li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/C++">Wikipedia: C++</a></li>
+			<li><a href="http://en.wikipedia.org/wiki/GNU_Compiler_Collection">Wikipedia: GNU Compiler Collection</a></li>
+			<li><a href="http://www.parashift.com/c%2B%2B-faq-lite/">C++ FAQ</a></li>
+		</ul>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzcpp">here</a>.</p>
+		<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzcpp">here</a>.</p>
 
-    <content:listing src="fizz-buzz-example.txt" brush="clang" />
+		<content:listing src="fizz-buzz-example.txt" brush="clang" />
 
-    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorscpp">here</a>.</p>
+		<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorscpp">here</a>.</p>
 
-    <content:listing src="100-doors-example.txt" brush="clang" />
+		<content:listing src="100-doors-example.txt" brush="clang" />
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/haskell/index.xnode
+++ b/pages/languages/haskell/index.xnode
@@ -1,52 +1,52 @@
 <content:page>
-  <header>
-    <content:heading>Haskell</content:heading>
+	<header>
+		<content:heading>Haskell</content:heading>
 
-    <p>Haskell is a <content:tt>statically typed</content:tt> pure <content:tt>functional</content:tt> programming language. It is based on highly sound academic theory and principal. Haskell has pioneered many modern concepts in functional programming such as <content:tt>monads</content:tt>, <content:tt>currying</content:tt> and advanced <content:tt>type inference</content:tt>.</p>
-  </header>
+		<p>Haskell is a <content:tt>statically typed</content:tt> pure <content:tt>functional</content:tt> programming language. It is based on highly sound academic theory and principal. Haskell has pioneered many modern concepts in functional programming such as <content:tt>monads</content:tt>, <content:tt>currying</content:tt> and advanced <content:tt>type inference</content:tt>.</p>
+	</header>
 
-  <main>
-    <p>Haskell can be either <content:tt>compiled</content:tt> or <content:tt>interpreted</content:tt> depending on the programming environment being used.</p>
+	<main>
+		<p>Haskell can be either <content:tt>compiled</content:tt> or <content:tt>interpreted</content:tt> depending on the programming environment being used.</p>
 
-    <h2>Why would I learn this language?</h2>
+		<h2>Why would I learn this language?</h2>
 
-    <p>Haskell is an advanced programming language based on rigorous theory. It has a strict type system that allows for many programming errors to be caught at compile time and has a functional design that makes concurrency and parallelism relatively easy.</p>
+		<p>Haskell is an advanced programming language based on rigorous theory. It has a strict type system that allows for many programming errors to be caught at compile time and has a functional design that makes concurrency and parallelism relatively easy.</p>
 
-    <p>Knowledge of higher order functions can provide the programmer with unique ways of solving certain problems, and lazy evaluation can make certain kinds of algorithms possible that aren't possible to implement in other languages (without modification of the algorithm)</p>
+		<p>Knowledge of higher order functions can provide the programmer with unique ways of solving certain problems, and lazy evaluation can make certain kinds of algorithms possible that aren't possible to implement in other languages (without modification of the algorithm)</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://tryhaskell.org/">Try Haskell</a></dt>
-      <dd>An online interactive tutorial.</dd>
+		<dl class="resources">
+			<dt><a href="http://tryhaskell.org/">Try Haskell</a></dt>
+			<dd>An online interactive tutorial.</dd>
 
-      <dt><a href="http://learnyouahaskell.com/">Learn You a Haskell for Great Good!</a></dt>
-      <dd>Comprehensive Set Tutorials &mdash; suitable for introduction to programming.</dd>
+			<dt><a href="http://learnyouahaskell.com/">Learn You a Haskell for Great Good!</a></dt>
+			<dd>Comprehensive Set Tutorials &mdash; suitable for introduction to programming.</dd>
 
-      <dt><a href="http://www.haskell.org/haskellwiki/Learn_Haskell_in_10_minutes">Learn Haskell in 10 minutes</a></dt>
-      <dd>A quick introduction to programming with Haskell suitable for those already familiar with programming.</dd>
+			<dt><a href="http://www.haskell.org/haskellwiki/Learn_Haskell_in_10_minutes">Learn Haskell in 10 minutes</a></dt>
+			<dd>A quick introduction to programming with Haskell suitable for those already familiar with programming.</dd>
 
-      <dt><a href="http://hackage.haskell.org/platform/new/contents.html">Haskell: Batteries Included</a></dt>
-      <dd>Set of resources for learning and teaching Haskell.</dd>
-    </dl>
+			<dt><a href="http://hackage.haskell.org/platform/new/contents.html">Haskell: Batteries Included</a></dt>
+			<dd>Set of resources for learning and teaching Haskell.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/Haskell_(programming_language)">Wikipedia: Haskell</a></li>
-      <li><a href="http://www.haskell.org/">Haskell</a> (Main Website)</li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/Haskell_(programming_language)">Wikipedia: Haskell</a></li>
+			<li><a href="http://www.haskell.org/">Haskell</a> (Main Website)</li>
+		</ul>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzhs">here</a>.</p>
+		<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzhs">here</a>.</p>
 
-    <content:listing src="fizz-buzz-example.txt" brush="haskell" />
+		<content:listing src="fizz-buzz-example.txt" brush="haskell" />
 
-    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorshs">here</a>.</p>
+		<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorshs">here</a>.</p>
 
-    <content:listing src="100-doors-example.txt" brush="haskell" />
+		<content:listing src="100-doors-example.txt" brush="haskell" />
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/haskell/index.xnode
+++ b/pages/languages/haskell/index.xnode
@@ -8,13 +8,13 @@
   <main>
     <p>Haskell can be either <content:tt>compiled</content:tt> or <content:tt>interpreted</content:tt> depending on the programming environment being used.</p>
 
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>Haskell is an advanced programming language based on rigorous theory. It has a strict type system that allows for many programming errors to be caught at compile time and has a functional design that makes concurrency and parallelism relatively easy.</p>
 
     <p>Knowledge of higher order functions can provide the programmer with unique ways of solving certain problems, and lazy evaluation can make certain kinds of algorithms possible that aren't possible to implement in other languages (without modification of the algorithm)</p>
 
-    <h3>Starting Points</h3>
+    <h2>Starting Points</h2>
 
     <dl class="resources">
       <dt><a href="http://tryhaskell.org/">Try Haskell</a></dt>
@@ -30,14 +30,14 @@
       <dd>Set of resources for learning and teaching Haskell.</dd>
     </dl>
 
-    <h3>Further Reading</h3>
+    <h2>Further Reading</h2>
 
     <ul>
       <li><a href="http://en.wikipedia.org/wiki/Haskell_(programming_language)">Wikipedia: Haskell</a></li>
       <li><a href="http://www.haskell.org/">Haskell</a> (Main Website)</li>
     </ul>
 
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzhs">here</a>.</p>
 

--- a/pages/languages/haskell/index.xnode
+++ b/pages/languages/haskell/index.xnode
@@ -1,48 +1,52 @@
 <content:page>
-	<content:heading>Haskell</content:heading>
-	
-	<p>Haskell is a <content:tt>statically typed</content:tt> pure <content:tt>functional</content:tt> programming language. It is based on highly sound academic theory and principal. Haskell has pioneered many modern concepts in functional programming such as <content:tt>monads</content:tt>, <content:tt>currying</content:tt> and advanced <content:tt>type inference</content:tt>.</p>
-	
-	<p>Haskell can be either <content:tt>compiled</content:tt> or <content:tt>interpreted</content:tt> depending on the programming environment being used.</p>
+  <header>
+    <content:heading>Haskell</content:heading>
 
-	<h3>Why would I learn this language?</h3>
-	
-	<p>Haskell is an advanced programming language based on rigorous theory. It has a strict type system that allows for many programming errors to be caught at compile time and has a functional design that makes concurrency and parallelism relatively easy.</p>
-	
-	<p>Knowledge of higher order functions can provide the programmer with unique ways of solving certain problems, and lazy evaluation can make certain kinds of algorithms possible that aren't possible to implement in other languages (without modification of the algorithm)</p>
-	
-	<h3>Starting Points</h3>
-	
-	<dl class="resources">
-		<dt><a href="http://tryhaskell.org/">Try Haskell</a></dt>
-		<dd>An online interactive tutorial.</dd>
+    <p>Haskell is a <content:tt>statically typed</content:tt> pure <content:tt>functional</content:tt> programming language. It is based on highly sound academic theory and principal. Haskell has pioneered many modern concepts in functional programming such as <content:tt>monads</content:tt>, <content:tt>currying</content:tt> and advanced <content:tt>type inference</content:tt>.</p>
+  </header>
 
-		<dt><a href="http://learnyouahaskell.com/">Learn You a Haskell for Great Good!</a></dt>
-		<dd>Comprehensive Set Tutorials &mdash; suitable for introduction to programming.</dd>
+  <main>
+    <p>Haskell can be either <content:tt>compiled</content:tt> or <content:tt>interpreted</content:tt> depending on the programming environment being used.</p>
 
-		<dt><a href="http://www.haskell.org/haskellwiki/Learn_Haskell_in_10_minutes">Learn Haskell in 10 minutes</a></dt>
-		<dd>A quick introduction to programming with Haskell suitable for those already familiar with programming.</dd>
+    <h3>Why would I learn this language?</h3>
 
-		<dt><a href="http://hackage.haskell.org/platform/new/contents.html">Haskell: Batteries Included</a></dt>
-		<dd>Set of resources for learning and teaching Haskell.</dd>
-	</dl>
-	
-	<h3>Further Reading</h3>
-	
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/Haskell_(programming_language)">Wikipedia: Haskell</a></li>
-		<li><a href="http://www.haskell.org/">Haskell</a> (Main Website)</li>
-	</ul>
+    <p>Haskell is an advanced programming language based on rigorous theory. It has a strict type system that allows for many programming errors to be caught at compile time and has a functional design that makes concurrency and parallelism relatively easy.</p>
 
-	<h3>Example Code</h3>
+    <p>Knowledge of higher order functions can provide the programmer with unique ways of solving certain problems, and lazy evaluation can make certain kinds of algorithms possible that aren't possible to implement in other languages (without modification of the algorithm)</p>
 
-	<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzhs">here</a>.</p>
+    <h3>Starting Points</h3>
 
-	<content:listing src="fizz-buzz-example.txt" brush="haskell" />
+    <dl class="resources">
+      <dt><a href="http://tryhaskell.org/">Try Haskell</a></dt>
+      <dd>An online interactive tutorial.</dd>
 
-	<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorshs">here</a>.</p>
+      <dt><a href="http://learnyouahaskell.com/">Learn You a Haskell for Great Good!</a></dt>
+      <dd>Comprehensive Set Tutorials &mdash; suitable for introduction to programming.</dd>
 
-	<content:listing src="100-doors-example.txt" brush="haskell" />
+      <dt><a href="http://www.haskell.org/haskellwiki/Learn_Haskell_in_10_minutes">Learn Haskell in 10 minutes</a></dt>
+      <dd>A quick introduction to programming with Haskell suitable for those already familiar with programming.</dd>
 
-	<comments />
+      <dt><a href="http://hackage.haskell.org/platform/new/contents.html">Haskell: Batteries Included</a></dt>
+      <dd>Set of resources for learning and teaching Haskell.</dd>
+    </dl>
+
+    <h3>Further Reading</h3>
+
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/Haskell_(programming_language)">Wikipedia: Haskell</a></li>
+      <li><a href="http://www.haskell.org/">Haskell</a> (Main Website)</li>
+    </ul>
+
+    <h3>Example Code</h3>
+
+    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzhs">here</a>.</p>
+
+    <content:listing src="fizz-buzz-example.txt" brush="haskell" />
+
+    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorshs">here</a>.</p>
+
+    <content:listing src="100-doors-example.txt" brush="haskell" />
+
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/java/index.xnode
+++ b/pages/languages/java/index.xnode
@@ -1,56 +1,56 @@
 <content:page>
-  <header>
-    <content:heading>Java</content:heading>
+	<header>
+		<content:heading>Java</content:heading>
 
-    <p>Java is a <content:tt>statically typed</content:tt> <content:tt>object oriented</content:tt> programming language. It was designed as a language for <content:tt>cross platform</content:tt> application development.</p>
-  </header>
+		<p>Java is a <content:tt>statically typed</content:tt> <content:tt>object oriented</content:tt> programming language. It was designed as a language for <content:tt>cross platform</content:tt> application development.</p>
+	</header>
 
-  <main>
-    <p>Java is generally <content:tt>compiled</content:tt> to <content:tt>bytecode</content:tt> that is then <content:tt>interpreted</content:tt> by the Java Virtual Machine. This allows the same <content:tt>bytecode</content:tt> to run on multiple platforms. The HotSpot JVM may also compile bytecode to native machine code for additional performance.</p>
+	<main>
+		<p>Java is generally <content:tt>compiled</content:tt> to <content:tt>bytecode</content:tt> that is then <content:tt>interpreted</content:tt> by the Java Virtual Machine. This allows the same <content:tt>bytecode</content:tt> to run on multiple platforms. The HotSpot JVM may also compile bytecode to native machine code for additional performance.</p>
 
-    <p>Other languages such as <content:tt>JRuby</content:tt> and <content:tt>Clojure</content:tt> can also run on top of the JVM, which makes it an interesting platform for programming language development.</p>
+		<p>Other languages such as <content:tt>JRuby</content:tt> and <content:tt>Clojure</content:tt> can also run on top of the JVM, which makes it an interesting platform for programming language development.</p>
 
-    <h2>Why would I learn this language?</h2>
+		<h2>Why would I learn this language?</h2>
 
-    <p>Java is a great language because it aims to provides a "write once, run anywhere" environment. While in practice, there are always additional complexities, Java code is generally cross platform.</p>
+		<p>Java is a great language because it aims to provides a "write once, run anywhere" environment. While in practice, there are always additional complexities, Java code is generally cross platform.</p>
 
-    <p>Java provides a highly structured environment which tends to promote good practices when it comes to software development, especially when more than one person is working on the source code.</p>
+		<p>Java provides a highly structured environment which tends to promote good practices when it comes to software development, especially when more than one person is working on the source code.</p>
 
-    <p>Java is not a purely <content:tt>object oriented</content:tt> language, because it has primitive types (which are not objects). This creates imperfections in both syntactic and semantic constructs within the language.</p>
+		<p>Java is not a purely <content:tt>object oriented</content:tt> language, because it has primitive types (which are not objects). This creates imperfections in both syntactic and semantic constructs within the language.</p>
 
-    <p>Due to the nature of all Java, code must always be defined within the scope of a class. This can requires a large amount of boiler plate code in certain scenarios.</p>
+		<p>Due to the nature of all Java, code must always be defined within the scope of a class. This can requires a large amount of boiler plate code in certain scenarios.</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://netbeans.org/kb/articles/learn-java.html">Learning Java - Resources</a></dt>
-      <dd>A fantastic set of resources for different levels of programmers.</dd>
+		<dl class="resources">
+			<dt><a href="http://netbeans.org/kb/articles/learn-java.html">Learning Java - Resources</a></dt>
+			<dd>A fantastic set of resources for different levels of programmers.</dd>
 
 
-      <dt><a href="http://java.sun.com/new2java/">New to Java Programming Center</a></dt>
-      <dd>A set of resources for new programmers who want to understand the different capabilities of Java.</dd>
+			<dt><a href="http://java.sun.com/new2java/">New to Java Programming Center</a></dt>
+			<dd>A set of resources for new programmers who want to understand the different capabilities of Java.</dd>
 
-      <dt><a href="http://java.sun.com/docs/books/tutorial/">The Java Tutorials</a></dt>
-      <dd>Practical guide for programmers who want to use the Java programming language.</dd>
-    </dl>
+			<dt><a href="http://java.sun.com/docs/books/tutorial/">The Java Tutorials</a></dt>
+			<dd>Practical guide for programmers who want to use the Java programming language.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/Java_(programming_language)">Wikipedia: Java</a></li>
-      <li><a href="http://www.java.com/">Java</a> (Main Website)</li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/Java_(programming_language)">Wikipedia: Java</a></li>
+			<li><a href="http://www.java.com/">Java</a> (Main Website)</li>
+		</ul>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this progam <a href="https://repl.it/@programmingdojo/fizzbuzzjava">here</a>.</p>
+		<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this progam <a href="https://repl.it/@programmingdojo/fizzbuzzjava">here</a>.</p>
 
-    <content:listing src="fizz-buzz-example.txt" brush="java" />
+		<content:listing src="fizz-buzz-example.txt" brush="java" />
 
-    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this progam <a href="https://repl.it/@programmingdojo/100doorsjava">here</a>.</p>
+		<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this progam <a href="https://repl.it/@programmingdojo/100doorsjava">here</a>.</p>
 
-    <content:listing src="100-doors-example.txt" brush="java" />
+		<content:listing src="100-doors-example.txt" brush="java" />
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/java/index.xnode
+++ b/pages/languages/java/index.xnode
@@ -10,7 +10,7 @@
 
     <p>Other languages such as <content:tt>JRuby</content:tt> and <content:tt>Clojure</content:tt> can also run on top of the JVM, which makes it an interesting platform for programming language development.</p>
 
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>Java is a great language because it aims to provides a "write once, run anywhere" environment. While in practice, there are always additional complexities, Java code is generally cross platform.</p>
 
@@ -20,7 +20,7 @@
 
     <p>Due to the nature of all Java, code must always be defined within the scope of a class. This can requires a large amount of boiler plate code in certain scenarios.</p>
 
-    <h3>Starting Points</h3>
+    <h2>Starting Points</h2>
 
     <dl class="resources">
       <dt><a href="http://netbeans.org/kb/articles/learn-java.html">Learning Java - Resources</a></dt>
@@ -34,14 +34,14 @@
       <dd>Practical guide for programmers who want to use the Java programming language.</dd>
     </dl>
 
-    <h3>Further Reading</h3>
+    <h2>Further Reading</h2>
 
     <ul>
       <li><a href="http://en.wikipedia.org/wiki/Java_(programming_language)">Wikipedia: Java</a></li>
       <li><a href="http://www.java.com/">Java</a> (Main Website)</li>
     </ul>
 
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this progam <a href="https://repl.it/@programmingdojo/fizzbuzzjava">here</a>.</p>
 

--- a/pages/languages/java/index.xnode
+++ b/pages/languages/java/index.xnode
@@ -1,52 +1,56 @@
 <content:page>
-	<content:heading>Java</content:heading>
-	
-	<p>Java is a <content:tt>statically typed</content:tt> <content:tt>object oriented</content:tt> programming language. It was designed as a language for <content:tt>cross platform</content:tt> application development.</p>
-	
-	<p>Java is generally <content:tt>compiled</content:tt> to <content:tt>bytecode</content:tt> that is then <content:tt>interpreted</content:tt> by the Java Virtual Machine. This allows the same <content:tt>bytecode</content:tt> to run on multiple platforms. The HotSpot JVM may also compile bytecode to native machine code for additional performance.</p>
-		
-	<p>Other languages such as <content:tt>JRuby</content:tt> and <content:tt>Clojure</content:tt> can also run on top of the JVM, which makes it an interesting platform for programming language development.</p>
+  <header>
+    <content:heading>Java</content:heading>
 
-	<h3>Why would I learn this language?</h3>
-	
-	<p>Java is a great language because it aims to provides a "write once, run anywhere" environment. While in practice, there are always additional complexities, Java code is generally cross platform.</p>
-	
-	<p>Java provides a highly structured environment which tends to promote good practices when it comes to software development, especially when more than one person is working on the source code.</p>
-	
-	<p>Java is not a purely <content:tt>object oriented</content:tt> language, because it has primitive types (which are not objects). This creates imperfections in both syntactic and semantic constructs within the language.</p>
-	
-	<p>Due to the nature of all Java, code must always be defined within the scope of a class. This can requires a large amount of boiler plate code in certain scenarios.</p>
-	
-	<h3>Starting Points</h3>
-	
-	<dl class="resources">
-		<dt><a href="http://netbeans.org/kb/articles/learn-java.html">Learning Java - Resources</a></dt>
-		<dd>A fantastic set of resources for different levels of programmers.</dd>
-	
-	
-		<dt><a href="http://java.sun.com/new2java/">New to Java Programming Center</a></dt>
-		<dd>A set of resources for new programmers who want to understand the different capabilities of Java.</dd>
-	
-		<dt><a href="http://java.sun.com/docs/books/tutorial/">The Java Tutorials</a></dt>
-		<dd>Practical guide for programmers who want to use the Java programming language.</dd>
-	</dl>
-	
-	<h3>Further Reading</h3>
-	
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/Java_(programming_language)">Wikipedia: Java</a></li>
-		<li><a href="http://www.java.com/">Java</a> (Main Website)</li>
-	</ul>
+    <p>Java is a <content:tt>statically typed</content:tt> <content:tt>object oriented</content:tt> programming language. It was designed as a language for <content:tt>cross platform</content:tt> application development.</p>
+  </header>
 
-	<h3>Example Code</h3>
+  <main>
+    <p>Java is generally <content:tt>compiled</content:tt> to <content:tt>bytecode</content:tt> that is then <content:tt>interpreted</content:tt> by the Java Virtual Machine. This allows the same <content:tt>bytecode</content:tt> to run on multiple platforms. The HotSpot JVM may also compile bytecode to native machine code for additional performance.</p>
 
-	<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this progam <a href="https://repl.it/@programmingdojo/fizzbuzzjava">here</a>.</p>
+    <p>Other languages such as <content:tt>JRuby</content:tt> and <content:tt>Clojure</content:tt> can also run on top of the JVM, which makes it an interesting platform for programming language development.</p>
 
-	<content:listing src="fizz-buzz-example.txt" brush="java" />
+    <h3>Why would I learn this language?</h3>
 
-	<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this progam <a href="https://repl.it/@programmingdojo/100doorsjava">here</a>.</p>
+    <p>Java is a great language because it aims to provides a "write once, run anywhere" environment. While in practice, there are always additional complexities, Java code is generally cross platform.</p>
 
-	<content:listing src="100-doors-example.txt" brush="java" />
+    <p>Java provides a highly structured environment which tends to promote good practices when it comes to software development, especially when more than one person is working on the source code.</p>
 
-	<comments />
+    <p>Java is not a purely <content:tt>object oriented</content:tt> language, because it has primitive types (which are not objects). This creates imperfections in both syntactic and semantic constructs within the language.</p>
+
+    <p>Due to the nature of all Java, code must always be defined within the scope of a class. This can requires a large amount of boiler plate code in certain scenarios.</p>
+
+    <h3>Starting Points</h3>
+
+    <dl class="resources">
+      <dt><a href="http://netbeans.org/kb/articles/learn-java.html">Learning Java - Resources</a></dt>
+      <dd>A fantastic set of resources for different levels of programmers.</dd>
+
+
+      <dt><a href="http://java.sun.com/new2java/">New to Java Programming Center</a></dt>
+      <dd>A set of resources for new programmers who want to understand the different capabilities of Java.</dd>
+
+      <dt><a href="http://java.sun.com/docs/books/tutorial/">The Java Tutorials</a></dt>
+      <dd>Practical guide for programmers who want to use the Java programming language.</dd>
+    </dl>
+
+    <h3>Further Reading</h3>
+
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/Java_(programming_language)">Wikipedia: Java</a></li>
+      <li><a href="http://www.java.com/">Java</a> (Main Website)</li>
+    </ul>
+
+    <h3>Example Code</h3>
+
+    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this progam <a href="https://repl.it/@programmingdojo/fizzbuzzjava">here</a>.</p>
+
+    <content:listing src="fizz-buzz-example.txt" brush="java" />
+
+    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this progam <a href="https://repl.it/@programmingdojo/100doorsjava">here</a>.</p>
+
+    <content:listing src="100-doors-example.txt" brush="java" />
+
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/javascript/index.xnode
+++ b/pages/languages/javascript/index.xnode
@@ -8,7 +8,7 @@
   <main>
     <p>JavaScript is generally <content:tt>interpreted</content:tt>.</p>
 
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>JavaScript is the language of the internet. To create an interactive website, JavaScript is the best choice. The web browser is a very capable application development platform and is available for the majority of platforms.</p>
 
@@ -16,7 +16,7 @@
 
     <p>JavaScript is a semantically simple language with first-class functions. This makes it very easy to use advanced functional concepts.</p>
 
-    <h3>Starting Points</h3>
+    <h2>Starting Points</h2>
 
     <dl class="resources">
       <dt><a href="http://eloquentjavascript.net/">Eloquent JavaScript</a></dt>
@@ -35,7 +35,7 @@
       <dd>A fantastic toolbox for writing simple cross-browser JavaScript code. Includes support for many advanced features.</dd>
     </dl>
 
-    <h3>Further Reading</h3>
+    <h2>Further Reading</h2>
 
     <ul>
       <li><a href="http://en.wikipedia.org/wiki/JavaScript">Wikipedia: JavaScript</a></li>
@@ -43,7 +43,7 @@
       <li><a href="http://www.codinghorror.com/blog/2008/08/secrets-of-the-javascript-ninjas.html">Secrets of the JavaScript Ninjas</a></li>
     </ul>
 
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzjs">here</a>.</p>
 

--- a/pages/languages/javascript/index.xnode
+++ b/pages/languages/javascript/index.xnode
@@ -1,55 +1,58 @@
 <content:page>
-	<content:heading>JavaScript</content:heading>
-	
-	<p>JavaScript is a <content:tt>dynamically typed</content:tt> <content:tt>imperative</content:tt> programming language with <content:tt>functional</content:tt> features. JavaScript is the main language for programming web pages; however it's use as a general purpose programming language is growing.</p>
-	
-	<p>JavaScript is generally <content:tt>interpreted</content:tt>.</p>
+  <header>
+    <content:heading>JavaScript</content:heading>
 
-	<h3>Why would I learn this language?</h3>
+    <p>JavaScript is a <content:tt>dynamically typed</content:tt> <content:tt>imperative</content:tt> programming language with <content:tt>functional</content:tt> features. JavaScript is the main language for programming web pages; however it's use as a general purpose programming language is growing.</p>
+  </header>
 
-	<p>JavaScript is the language of the internet. To create an interactive website, JavaScript is the best choice. The web browser is a very capable application development platform and is available for the majority of platforms.</p>
+  <main>
+    <p>JavaScript is generally <content:tt>interpreted</content:tt>.</p>
 
-	<p>JavaScript has excellent debugging tools and due to the nature of its execution environment, provides a rich set of elements (such as images, audio and text) for displaying results.</p>
+    <h3>Why would I learn this language?</h3>
 
-	<p>JavaScript is a semantically simple language with first-class functions. This makes it very easy to use advanced functional concepts.</p>
-	
-	<h3>Starting Points</h3>
+    <p>JavaScript is the language of the internet. To create an interactive website, JavaScript is the best choice. The web browser is a very capable application development platform and is available for the majority of platforms.</p>
 
-	<dl class="resources">
-		<dt><a href="http://eloquentjavascript.net/">Eloquent JavaScript</a></dt>
-		<dd>An interactive online tutorial for the beginner programmer.</dd>
-		
-		<dt><a href="http://ejohn.org/apps/learn/">Learning Advanced Javascript</a></dt>
-		<dd>A set of tutorials covering advanced computer programming topics in JavaScript.</dd>
-		
-		<dt><a href="http://getfirebug.com/">Firebug</a></dt>
-		<dd>A fantastic tool for developing and debugging JavaScript in <a href="http://getfirefox.com">FireFox</a>.</dd>
-		
-		<dt><a href="http://developer.mozilla.org/en/docs/Main_Page">Mozilla Developer Network</a></dt>
-		<dd>A great set of resources and documentation for programming JavaScript in the web browser.</dd>
-		
-		<dt><a href="http://www.jquery.org/">jQuery</a></dt>
-		<dd>A fantastic toolbox for writing simple cross-browser JavaScript code. Includes support for many advanced features.</dd>
-	</dl>
+    <p>JavaScript has excellent debugging tools and due to the nature of its execution environment, provides a rich set of elements (such as images, audio and text) for displaying results.</p>
 
-	<h3>Further Reading</h3>
-	
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/JavaScript">Wikipedia: JavaScript</a></li>
-		<li><a href="http://en.wikipedia.org/wiki/Server-side_JavaScript">Wikipedia: Server-side JavaScript</a></li>
-		<li><a href="http://www.codinghorror.com/blog/2008/08/secrets-of-the-javascript-ninjas.html">Secrets of the JavaScript Ninjas</a></li>
-	</ul>
+    <p>JavaScript is a semantically simple language with first-class functions. This makes it very easy to use advanced functional concepts.</p>
 
-	<h3>Example Code</h3>
+    <h3>Starting Points</h3>
 
-	<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzjs">here</a>.</p>
+    <dl class="resources">
+      <dt><a href="http://eloquentjavascript.net/">Eloquent JavaScript</a></dt>
+      <dd>An interactive online tutorial for the beginner programmer.</dd>
 
-	<content:listing src="fizz-buzz-example.txt" brush="javascript" />
+      <dt><a href="http://ejohn.org/apps/learn/">Learning Advanced Javascript</a></dt>
+      <dd>A set of tutorials covering advanced computer programming topics in JavaScript.</dd>
 
-	<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsjs">here</a>.</p>
+      <dt><a href="http://getfirebug.com/">Firebug</a></dt>
+      <dd>A fantastic tool for developing and debugging JavaScript in <a href="http://getfirefox.com">FireFox</a>.</dd>
 
-	<content:listing src="100-doors-example.txt" brush="javascript" />
+      <dt><a href="http://developer.mozilla.org/en/docs/Main_Page">Mozilla Developer Network</a></dt>
+      <dd>A great set of resources and documentation for programming JavaScript in the web browser.</dd>
 
-	<comments />
+      <dt><a href="http://www.jquery.org/">jQuery</a></dt>
+      <dd>A fantastic toolbox for writing simple cross-browser JavaScript code. Includes support for many advanced features.</dd>
+    </dl>
+
+    <h3>Further Reading</h3>
+
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/JavaScript">Wikipedia: JavaScript</a></li>
+      <li><a href="http://en.wikipedia.org/wiki/Server-side_JavaScript">Wikipedia: Server-side JavaScript</a></li>
+      <li><a href="http://www.codinghorror.com/blog/2008/08/secrets-of-the-javascript-ninjas.html">Secrets of the JavaScript Ninjas</a></li>
+    </ul>
+
+    <h3>Example Code</h3>
+
+    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzjs">here</a>.</p>
+
+    <content:listing src="fizz-buzz-example.txt" brush="javascript" />
+
+    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsjs">here</a>.</p>
+
+    <content:listing src="100-doors-example.txt" brush="javascript" />
+
+    <content:comments />
+  </main>
 </content:page>
-

--- a/pages/languages/javascript/index.xnode
+++ b/pages/languages/javascript/index.xnode
@@ -1,58 +1,58 @@
 <content:page>
-  <header>
-    <content:heading>JavaScript</content:heading>
+	<header>
+		<content:heading>JavaScript</content:heading>
 
-    <p>JavaScript is a <content:tt>dynamically typed</content:tt> <content:tt>imperative</content:tt> programming language with <content:tt>functional</content:tt> features. JavaScript is the main language for programming web pages; however it's use as a general purpose programming language is growing.</p>
-  </header>
+		<p>JavaScript is a <content:tt>dynamically typed</content:tt> <content:tt>imperative</content:tt> programming language with <content:tt>functional</content:tt> features. JavaScript is the main language for programming web pages; however it's use as a general purpose programming language is growing.</p>
+	</header>
 
-  <main>
-    <p>JavaScript is generally <content:tt>interpreted</content:tt>.</p>
+	<main>
+		<p>JavaScript is generally <content:tt>interpreted</content:tt>.</p>
 
-    <h2>Why would I learn this language?</h2>
+		<h2>Why would I learn this language?</h2>
 
-    <p>JavaScript is the language of the internet. To create an interactive website, JavaScript is the best choice. The web browser is a very capable application development platform and is available for the majority of platforms.</p>
+		<p>JavaScript is the language of the internet. To create an interactive website, JavaScript is the best choice. The web browser is a very capable application development platform and is available for the majority of platforms.</p>
 
-    <p>JavaScript has excellent debugging tools and due to the nature of its execution environment, provides a rich set of elements (such as images, audio and text) for displaying results.</p>
+		<p>JavaScript has excellent debugging tools and due to the nature of its execution environment, provides a rich set of elements (such as images, audio and text) for displaying results.</p>
 
-    <p>JavaScript is a semantically simple language with first-class functions. This makes it very easy to use advanced functional concepts.</p>
+		<p>JavaScript is a semantically simple language with first-class functions. This makes it very easy to use advanced functional concepts.</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://eloquentjavascript.net/">Eloquent JavaScript</a></dt>
-      <dd>An interactive online tutorial for the beginner programmer.</dd>
+		<dl class="resources">
+			<dt><a href="http://eloquentjavascript.net/">Eloquent JavaScript</a></dt>
+			<dd>An interactive online tutorial for the beginner programmer.</dd>
 
-      <dt><a href="http://ejohn.org/apps/learn/">Learning Advanced Javascript</a></dt>
-      <dd>A set of tutorials covering advanced computer programming topics in JavaScript.</dd>
+			<dt><a href="http://ejohn.org/apps/learn/">Learning Advanced Javascript</a></dt>
+			<dd>A set of tutorials covering advanced computer programming topics in JavaScript.</dd>
 
-      <dt><a href="http://getfirebug.com/">Firebug</a></dt>
-      <dd>A fantastic tool for developing and debugging JavaScript in <a href="http://getfirefox.com">FireFox</a>.</dd>
+			<dt><a href="http://getfirebug.com/">Firebug</a></dt>
+			<dd>A fantastic tool for developing and debugging JavaScript in <a href="http://getfirefox.com">FireFox</a>.</dd>
 
-      <dt><a href="http://developer.mozilla.org/en/docs/Main_Page">Mozilla Developer Network</a></dt>
-      <dd>A great set of resources and documentation for programming JavaScript in the web browser.</dd>
+			<dt><a href="http://developer.mozilla.org/en/docs/Main_Page">Mozilla Developer Network</a></dt>
+			<dd>A great set of resources and documentation for programming JavaScript in the web browser.</dd>
 
-      <dt><a href="http://www.jquery.org/">jQuery</a></dt>
-      <dd>A fantastic toolbox for writing simple cross-browser JavaScript code. Includes support for many advanced features.</dd>
-    </dl>
+			<dt><a href="http://www.jquery.org/">jQuery</a></dt>
+			<dd>A fantastic toolbox for writing simple cross-browser JavaScript code. Includes support for many advanced features.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/JavaScript">Wikipedia: JavaScript</a></li>
-      <li><a href="http://en.wikipedia.org/wiki/Server-side_JavaScript">Wikipedia: Server-side JavaScript</a></li>
-      <li><a href="http://www.codinghorror.com/blog/2008/08/secrets-of-the-javascript-ninjas.html">Secrets of the JavaScript Ninjas</a></li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/JavaScript">Wikipedia: JavaScript</a></li>
+			<li><a href="http://en.wikipedia.org/wiki/Server-side_JavaScript">Wikipedia: Server-side JavaScript</a></li>
+			<li><a href="http://www.codinghorror.com/blog/2008/08/secrets-of-the-javascript-ninjas.html">Secrets of the JavaScript Ninjas</a></li>
+		</ul>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzjs">here</a>.</p>
+		<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzjs">here</a>.</p>
 
-    <content:listing src="fizz-buzz-example.txt" brush="javascript" />
+		<content:listing src="fizz-buzz-example.txt" brush="javascript" />
 
-    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsjs">here</a>.</p>
+		<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsjs">here</a>.</p>
 
-    <content:listing src="100-doors-example.txt" brush="javascript" />
+		<content:listing src="100-doors-example.txt" brush="javascript" />
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/pascal/index.xnode
+++ b/pages/languages/pascal/index.xnode
@@ -1,43 +1,47 @@
 <content:page>
-	<content:heading>Pascal</content:heading>
-	
-	<p>Pascal is a <content:tt>statically typed</content:tt> programming language. It was designed as a language for education. It is generally a <content:tt>compiled</content:tt> language.</p>
-	
-	<p>Several derivatives of Pascal exist which enhance the language, such as <content:tt>Object Pascal</content:tt>.</p>
+  <header>
+    <content:heading>Pascal</content:heading>
 
-	<h3>Why would I learn this language?</h3>
+    <p>Pascal is a <content:tt>statically typed</content:tt> programming language. It was designed as a language for education. It is generally a <content:tt>compiled</content:tt> language.</p>
+  </header>
 
-	<p>Pascal is considered to be one of a few languages which one can learn completely. The language is deliberately limited and (by default) there are few external libraries. In this sense, learning Pascal is a finite process.</p>
-	
-	<p>Pascal has a simple syntax and easy to understand type system. Programs are generally fairly easy to read and write.</p>
-	
-	<p>Pascal is a fairly well established language, but is also not very modern.</p>
-	
-	<h3>Starting Points</h3>
+  <main>
+    <p>Several derivatives of Pascal exist which enhance the language, such as <content:tt>Object Pascal</content:tt>.</p>
 
-	<dl class="resources">
-		<dt><a href="http://www.taoyue.com/tutorials/pascal/">Learn Pascal</a></dt>
-		<dd>Beginner guide to programming using Pascal.</dd>
+    <h3>Why would I learn this language?</h3>
 
-		<dt><a href="http://www.freepascal.org/">Free Pascal</a></dt>
-		<dd>Open Source Compiler for Pascal and Object Pascal.</dd>
-	</dl>
-	
-	<h3>Further Reading</h3>
-	
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/Pascal_(programming_language)">Wikipedia: Pascal</a></li>
-	</ul>
+    <p>Pascal is considered to be one of a few languages which one can learn completely. The language is deliberately limited and (by default) there are few external libraries. In this sense, learning Pascal is a finite process.</p>
 
-	<h3>Example Code</h3>
+    <p>Pascal has a simple syntax and easy to understand type system. Programs are generally fairly easy to read and write.</p>
 
-	<p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
+    <p>Pascal is a fairly well established language, but is also not very modern.</p>
 
-	<content:listing src="fizz-buzz-example.txt" brush="pascal" />
+    <h3>Starting Points</h3>
 
-	<p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
+    <dl class="resources">
+      <dt><a href="http://www.taoyue.com/tutorials/pascal/">Learn Pascal</a></dt>
+      <dd>Beginner guide to programming using Pascal.</dd>
 
-	<content:listing src="100-doors-example.txt" brush="pascal" />
-	
-	<comments />
+      <dt><a href="http://www.freepascal.org/">Free Pascal</a></dt>
+      <dd>Open Source Compiler for Pascal and Object Pascal.</dd>
+    </dl>
+
+    <h3>Further Reading</h3>
+
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/Pascal_(programming_language)">Wikipedia: Pascal</a></li>
+    </ul>
+
+    <h3>Example Code</h3>
+
+    <p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
+
+    <content:listing src="fizz-buzz-example.txt" brush="pascal" />
+
+    <p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
+
+    <content:listing src="100-doors-example.txt" brush="pascal" />
+
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/pascal/index.xnode
+++ b/pages/languages/pascal/index.xnode
@@ -8,7 +8,7 @@
   <main>
     <p>Several derivatives of Pascal exist which enhance the language, such as <content:tt>Object Pascal</content:tt>.</p>
 
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>Pascal is considered to be one of a few languages which one can learn completely. The language is deliberately limited and (by default) there are few external libraries. In this sense, learning Pascal is a finite process.</p>
 
@@ -16,7 +16,7 @@
 
     <p>Pascal is a fairly well established language, but is also not very modern.</p>
 
-    <h3>Starting Points</h3>
+    <h2>Starting Points</h2>
 
     <dl class="resources">
       <dt><a href="http://www.taoyue.com/tutorials/pascal/">Learn Pascal</a></dt>
@@ -26,13 +26,13 @@
       <dd>Open Source Compiler for Pascal and Object Pascal.</dd>
     </dl>
 
-    <h3>Further Reading</h3>
+    <h2>Further Reading</h2>
 
     <ul>
       <li><a href="http://en.wikipedia.org/wiki/Pascal_(programming_language)">Wikipedia: Pascal</a></li>
     </ul>
 
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
 

--- a/pages/languages/pascal/index.xnode
+++ b/pages/languages/pascal/index.xnode
@@ -1,47 +1,47 @@
 <content:page>
-  <header>
-    <content:heading>Pascal</content:heading>
+	<header>
+		<content:heading>Pascal</content:heading>
 
-    <p>Pascal is a <content:tt>statically typed</content:tt> programming language. It was designed as a language for education. It is generally a <content:tt>compiled</content:tt> language.</p>
-  </header>
+		<p>Pascal is a <content:tt>statically typed</content:tt> programming language. It was designed as a language for education. It is generally a <content:tt>compiled</content:tt> language.</p>
+	</header>
 
-  <main>
-    <p>Several derivatives of Pascal exist which enhance the language, such as <content:tt>Object Pascal</content:tt>.</p>
+	<main>
+		<p>Several derivatives of Pascal exist which enhance the language, such as <content:tt>Object Pascal</content:tt>.</p>
 
-    <h2>Why would I learn this language?</h2>
+		<h2>Why would I learn this language?</h2>
 
-    <p>Pascal is considered to be one of a few languages which one can learn completely. The language is deliberately limited and (by default) there are few external libraries. In this sense, learning Pascal is a finite process.</p>
+		<p>Pascal is considered to be one of a few languages which one can learn completely. The language is deliberately limited and (by default) there are few external libraries. In this sense, learning Pascal is a finite process.</p>
 
-    <p>Pascal has a simple syntax and easy to understand type system. Programs are generally fairly easy to read and write.</p>
+		<p>Pascal has a simple syntax and easy to understand type system. Programs are generally fairly easy to read and write.</p>
 
-    <p>Pascal is a fairly well established language, but is also not very modern.</p>
+		<p>Pascal is a fairly well established language, but is also not very modern.</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://www.taoyue.com/tutorials/pascal/">Learn Pascal</a></dt>
-      <dd>Beginner guide to programming using Pascal.</dd>
+		<dl class="resources">
+			<dt><a href="http://www.taoyue.com/tutorials/pascal/">Learn Pascal</a></dt>
+			<dd>Beginner guide to programming using Pascal.</dd>
 
-      <dt><a href="http://www.freepascal.org/">Free Pascal</a></dt>
-      <dd>Open Source Compiler for Pascal and Object Pascal.</dd>
-    </dl>
+			<dt><a href="http://www.freepascal.org/">Free Pascal</a></dt>
+			<dd>Open Source Compiler for Pascal and Object Pascal.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/Pascal_(programming_language)">Wikipedia: Pascal</a></li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/Pascal_(programming_language)">Wikipedia: Pascal</a></li>
+		</ul>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
+		<p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
 
-    <content:listing src="fizz-buzz-example.txt" brush="pascal" />
+		<content:listing src="fizz-buzz-example.txt" brush="pascal" />
 
-    <p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
+		<p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
 
-    <content:listing src="100-doors-example.txt" brush="pascal" />
+		<content:listing src="100-doors-example.txt" brush="pascal" />
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/perl/index.xnode
+++ b/pages/languages/perl/index.xnode
@@ -1,49 +1,49 @@
 <content:page>
-  <header>
-    <content:heading>Perl</content:heading>
+	<header>
+		<content:heading>Perl</content:heading>
 
-    <p>Perl is an <content:tt>dynamically typed</content:tt> programming language. It was initially designed as a language for system administration, but has since grown to provide a wide range of functionality in many different areas of software development and computer science.</p>
-  </header>
+		<p>Perl is an <content:tt>dynamically typed</content:tt> programming language. It was initially designed as a language for system administration, but has since grown to provide a wide range of functionality in many different areas of software development and computer science.</p>
+	</header>
 
-  <main>
-    <p>Perl has <content:tt>imperative</content:tt>, <content:tt>functional</content:tt> and <content:tt>object oriented</content:tt> features, including both <content:tt>lexical scoping</content:tt> and <content:tt>dynamic scoping</content:tt> (although the latter isn't used much). Perl source code is executed by the Perl <content:tt to="interpreted">interpreter</content:tt> which internally <content:tt>compiles</content:tt> the code to bytecode for better performance.</p>
+	<main>
+		<p>Perl has <content:tt>imperative</content:tt>, <content:tt>functional</content:tt> and <content:tt>object oriented</content:tt> features, including both <content:tt>lexical scoping</content:tt> and <content:tt>dynamic scoping</content:tt> (although the latter isn't used much). Perl source code is executed by the Perl <content:tt to="interpreted">interpreter</content:tt> which internally <content:tt>compiles</content:tt> the code to bytecode for better performance.</p>
 
-    <h2>Why would I learn this language?</h2>
+		<h2>Why would I learn this language?</h2>
 
-    <p>Perl is a flexible dynamic programming language with many features. It is a great tool for system administration, web development and software testing.</p>
+		<p>Perl is a flexible dynamic programming language with many features. It is a great tool for system administration, web development and software testing.</p>
 
-    <p>Perl code is very succinct and can be written very quickly, while still having good performance.</p>
+		<p>Perl code is very succinct and can be written very quickly, while still having good performance.</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://perl-begin.org/">Perl Beginners' Site</a></dt>
-      <dd>A set of resources aimed at beginners interested in learning about Perl.</dd>
+		<dl class="resources">
+			<dt><a href="http://perl-begin.org/">Perl Beginners' Site</a></dt>
+			<dd>A set of resources aimed at beginners interested in learning about Perl.</dd>
 
-      <dt><a href="http://learn.perl.org/">Learning Perl</a></dt>
-      <dd>Resources and references for learning Perl.</dd>
+			<dt><a href="http://learn.perl.org/">Learning Perl</a></dt>
+			<dd>Resources and references for learning Perl.</dd>
 
-      <dt><a href="http://www.perl.org/books/beginning-perl/">Beginning Perl</a></dt>
-      <dd>A beginner guide to install program using Perl.</dd>
-    </dl>
+			<dt><a href="http://www.perl.org/books/beginning-perl/">Beginning Perl</a></dt>
+			<dd>A beginner guide to install program using Perl.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/Perl_(programming_language)">Wikipedia: Perl</a></li>
-      <li><a href="http://www.perl.org/">Perl</a> (Main Website)</li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/Perl_(programming_language)">Wikipedia: Perl</a></li>
+			<li><a href="http://www.perl.org/">Perl</a> (Main Website)</li>
+		</ul>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
+		<p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
 
-    <content:listing src="fizz-buzz-example.txt" brush="perl5" />
+		<content:listing src="fizz-buzz-example.txt" brush="perl5" />
 
-    <p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
+		<p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
 
-    <content:listing src="100-doors-example.txt" brush="perl5" />
+		<content:listing src="100-doors-example.txt" brush="perl5" />
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/perl/index.xnode
+++ b/pages/languages/perl/index.xnode
@@ -8,13 +8,13 @@
   <main>
     <p>Perl has <content:tt>imperative</content:tt>, <content:tt>functional</content:tt> and <content:tt>object oriented</content:tt> features, including both <content:tt>lexical scoping</content:tt> and <content:tt>dynamic scoping</content:tt> (although the latter isn't used much). Perl source code is executed by the Perl <content:tt to="interpreted">interpreter</content:tt> which internally <content:tt>compiles</content:tt> the code to bytecode for better performance.</p>
 
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>Perl is a flexible dynamic programming language with many features. It is a great tool for system administration, web development and software testing.</p>
 
     <p>Perl code is very succinct and can be written very quickly, while still having good performance.</p>
 
-    <h3>Starting Points</h3>
+    <h2>Starting Points</h2>
 
     <dl class="resources">
       <dt><a href="http://perl-begin.org/">Perl Beginners' Site</a></dt>
@@ -27,14 +27,14 @@
       <dd>A beginner guide to install program using Perl.</dd>
     </dl>
 
-    <h3>Further Reading</h3>
+    <h2>Further Reading</h2>
 
     <ul>
       <li><a href="http://en.wikipedia.org/wiki/Perl_(programming_language)">Wikipedia: Perl</a></li>
       <li><a href="http://www.perl.org/">Perl</a> (Main Website)</li>
     </ul>
 
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
 

--- a/pages/languages/perl/index.xnode
+++ b/pages/languages/perl/index.xnode
@@ -1,45 +1,49 @@
 <content:page>
-	<content:heading>Perl</content:heading>
-	
-	<p>Perl is an <content:tt>dynamically typed</content:tt> programming language. It was initially designed as a language for system administration, but has since grown to provide a wide range of functionality in many different areas of software development and computer science.</p>
-	
-	<p>Perl has <content:tt>imperative</content:tt>, <content:tt>functional</content:tt> and <content:tt>object oriented</content:tt> features, including both <content:tt>lexical scoping</content:tt> and <content:tt>dynamic scoping</content:tt> (although the latter isn't used much). Perl source code is executed by the Perl <content:tt to="interpreted">interpreter</content:tt> which internally <content:tt>compiles</content:tt> the code to bytecode for better performance.</p>
+  <header>
+    <content:heading>Perl</content:heading>
 
-	<h3>Why would I learn this language?</h3>
+    <p>Perl is an <content:tt>dynamically typed</content:tt> programming language. It was initially designed as a language for system administration, but has since grown to provide a wide range of functionality in many different areas of software development and computer science.</p>
+  </header>
 
-	<p>Perl is a flexible dynamic programming language with many features. It is a great tool for system administration, web development and software testing.</p>
+  <main>
+    <p>Perl has <content:tt>imperative</content:tt>, <content:tt>functional</content:tt> and <content:tt>object oriented</content:tt> features, including both <content:tt>lexical scoping</content:tt> and <content:tt>dynamic scoping</content:tt> (although the latter isn't used much). Perl source code is executed by the Perl <content:tt to="interpreted">interpreter</content:tt> which internally <content:tt>compiles</content:tt> the code to bytecode for better performance.</p>
 
-	<p>Perl code is very succinct and can be written very quickly, while still having good performance.</p>
+    <h3>Why would I learn this language?</h3>
 
-	<h3>Starting Points</h3>
+    <p>Perl is a flexible dynamic programming language with many features. It is a great tool for system administration, web development and software testing.</p>
 
-	<dl class="resources">
-		<dt><a href="http://perl-begin.org/">Perl Beginners' Site</a></dt>
-		<dd>A set of resources aimed at beginners interested in learning about Perl.</dd>
-		
-		<dt><a href="http://learn.perl.org/">Learning Perl</a></dt>
-		<dd>Resources and references for learning Perl.</dd>
+    <p>Perl code is very succinct and can be written very quickly, while still having good performance.</p>
 
-		<dt><a href="http://www.perl.org/books/beginning-perl/">Beginning Perl</a></dt>
-		<dd>A beginner guide to install program using Perl.</dd>
-	</dl>
+    <h3>Starting Points</h3>
 
-	<h3>Further Reading</h3>
+    <dl class="resources">
+      <dt><a href="http://perl-begin.org/">Perl Beginners' Site</a></dt>
+      <dd>A set of resources aimed at beginners interested in learning about Perl.</dd>
 
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/Perl_(programming_language)">Wikipedia: Perl</a></li>
-		<li><a href="http://www.perl.org/">Perl</a> (Main Website)</li>
-	</ul>
+      <dt><a href="http://learn.perl.org/">Learning Perl</a></dt>
+      <dd>Resources and references for learning Perl.</dd>
 
-	<h3>Example Code</h3>
+      <dt><a href="http://www.perl.org/books/beginning-perl/">Beginning Perl</a></dt>
+      <dd>A beginner guide to install program using Perl.</dd>
+    </dl>
 
-	<p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
+    <h3>Further Reading</h3>
 
-	<content:listing src="fizz-buzz-example.txt" brush="perl5" />
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/Perl_(programming_language)">Wikipedia: Perl</a></li>
+      <li><a href="http://www.perl.org/">Perl</a> (Main Website)</li>
+    </ul>
 
-	<p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
+    <h3>Example Code</h3>
 
-	<content:listing src="100-doors-example.txt" brush="perl5" />
+    <p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
 
-	<comments />
+    <content:listing src="fizz-buzz-example.txt" brush="perl5" />
+
+    <p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
+
+    <content:listing src="100-doors-example.txt" brush="perl5" />
+
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/php/index.xnode
+++ b/pages/languages/php/index.xnode
@@ -1,41 +1,45 @@
 <content:page>
-	<content:heading>PHP</content:heading>
-	
-	<p>PHP is a <content:tt>dynamically typed</content:tt> language. It supports a number of different programming paradigms including <content:tt>imperative</content:tt> and <content:tt>object oriented</content:tt> features. PHP code is generally <content:tt>interpreted</content:tt> but several systems for producing <content:tt>compiled</content:tt> code are available.</p>
-	
-	<p>PHP is designed for developing web applications, and generally has little use in other scenarios. It is easy to integrate with a wide range of other technologies.</p>
-	
-	<h3>Why would I learn this language?</h3>
+  <header>
+    <content:heading>PHP</content:heading>
 
-	<p>PHP as an environment is very easy to deploy. It is generally combined with Linux, Apache and MySQL (a LAMP setup). This makes it ideal for simple web applications and projects.</p>
-	
-	<p>One great feature of PHP as a community is the documentation. There are fantastic resources available on the main PHP website, and there are many external resources discussing PHP programming and related topics.</p>
-	
-	<p>PHP provides integration with many other libraries, such as databases, image manipulation and network communication. However, each external library tends to have its own syntax and semantic behavior. This can make larger programs unmanageable without careful planning.</p>
-	
-	<h3>Starting Points</h3>
+    <p>PHP is a <content:tt>dynamically typed</content:tt> language. It supports a number of different programming paradigms including <content:tt>imperative</content:tt> and <content:tt>object oriented</content:tt> features. PHP code is generally <content:tt>interpreted</content:tt> but several systems for producing <content:tt>compiled</content:tt> code are available.</p>
+  </header>
 
-	<dl class="resources">
-		<dt><a href="http://en.wikibooks.org/wiki/PHP_Programming">PHP Programming Wikibook</a></dt>
-		<dd>A comprehensive guide to learning to program using PHP.</dd>
-	</dl>
-	
-	<h3>Further Reading</h3>
-	
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/PHP">Wikipedia: PHP</a></li>
-		<li><a href="http://www.php.net/">PHP: Hypertext Preprocessor</a> (Main Website)</li>
-	</ul>
+  <main>
+    <p>PHP is designed for developing web applications, and generally has little use in other scenarios. It is easy to integrate with a wide range of other technologies.</p>
 
-	<h3>Example Code</h3>
+    <h3>Why would I learn this language?</h3>
 
-	<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzphp">here</a>.</p>
+    <p>PHP as an environment is very easy to deploy. It is generally combined with Linux, Apache and MySQL (a LAMP setup). This makes it ideal for simple web applications and projects.</p>
 
-	<content:listing src="fizz-buzz-example.txt" brush="html" />
+    <p>One great feature of PHP as a community is the documentation. There are fantastic resources available on the main PHP website, and there are many external resources discussing PHP programming and related topics.</p>
 
-	<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsphp">here</a>.</p>
-	
-	<content:listing src="100-doors-example.txt" brush="html" />
+    <p>PHP provides integration with many other libraries, such as databases, image manipulation and network communication. However, each external library tends to have its own syntax and semantic behavior. This can make larger programs unmanageable without careful planning.</p>
 
-	<comments />
+    <h3>Starting Points</h3>
+
+    <dl class="resources">
+      <dt><a href="http://en.wikibooks.org/wiki/PHP_Programming">PHP Programming Wikibook</a></dt>
+      <dd>A comprehensive guide to learning to program using PHP.</dd>
+    </dl>
+
+    <h3>Further Reading</h3>
+
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/PHP">Wikipedia: PHP</a></li>
+      <li><a href="http://www.php.net/">PHP: Hypertext Preprocessor</a> (Main Website)</li>
+    </ul>
+
+    <h3>Example Code</h3>
+
+    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzphp">here</a>.</p>
+
+    <content:listing src="fizz-buzz-example.txt" brush="html" />
+
+    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsphp">here</a>.</p>
+
+    <content:listing src="100-doors-example.txt" brush="html" />
+
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/php/index.xnode
+++ b/pages/languages/php/index.xnode
@@ -8,7 +8,7 @@
   <main>
     <p>PHP is designed for developing web applications, and generally has little use in other scenarios. It is easy to integrate with a wide range of other technologies.</p>
 
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>PHP as an environment is very easy to deploy. It is generally combined with Linux, Apache and MySQL (a LAMP setup). This makes it ideal for simple web applications and projects.</p>
 
@@ -16,21 +16,21 @@
 
     <p>PHP provides integration with many other libraries, such as databases, image manipulation and network communication. However, each external library tends to have its own syntax and semantic behavior. This can make larger programs unmanageable without careful planning.</p>
 
-    <h3>Starting Points</h3>
+    <h2>Starting Points</h2>
 
     <dl class="resources">
       <dt><a href="http://en.wikibooks.org/wiki/PHP_Programming">PHP Programming Wikibook</a></dt>
       <dd>A comprehensive guide to learning to program using PHP.</dd>
     </dl>
 
-    <h3>Further Reading</h3>
+    <h2>Further Reading</h2>
 
     <ul>
       <li><a href="http://en.wikipedia.org/wiki/PHP">Wikipedia: PHP</a></li>
       <li><a href="http://www.php.net/">PHP: Hypertext Preprocessor</a> (Main Website)</li>
     </ul>
 
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzphp">here</a>.</p>
 

--- a/pages/languages/php/index.xnode
+++ b/pages/languages/php/index.xnode
@@ -1,45 +1,45 @@
 <content:page>
-  <header>
-    <content:heading>PHP</content:heading>
+	<header>
+		<content:heading>PHP</content:heading>
 
-    <p>PHP is a <content:tt>dynamically typed</content:tt> language. It supports a number of different programming paradigms including <content:tt>imperative</content:tt> and <content:tt>object oriented</content:tt> features. PHP code is generally <content:tt>interpreted</content:tt> but several systems for producing <content:tt>compiled</content:tt> code are available.</p>
-  </header>
+		<p>PHP is a <content:tt>dynamically typed</content:tt> language. It supports a number of different programming paradigms including <content:tt>imperative</content:tt> and <content:tt>object oriented</content:tt> features. PHP code is generally <content:tt>interpreted</content:tt> but several systems for producing <content:tt>compiled</content:tt> code are available.</p>
+	</header>
 
-  <main>
-    <p>PHP is designed for developing web applications, and generally has little use in other scenarios. It is easy to integrate with a wide range of other technologies.</p>
+	<main>
+		<p>PHP is designed for developing web applications, and generally has little use in other scenarios. It is easy to integrate with a wide range of other technologies.</p>
 
-    <h2>Why would I learn this language?</h2>
+		<h2>Why would I learn this language?</h2>
 
-    <p>PHP as an environment is very easy to deploy. It is generally combined with Linux, Apache and MySQL (a LAMP setup). This makes it ideal for simple web applications and projects.</p>
+		<p>PHP as an environment is very easy to deploy. It is generally combined with Linux, Apache and MySQL (a LAMP setup). This makes it ideal for simple web applications and projects.</p>
 
-    <p>One great feature of PHP as a community is the documentation. There are fantastic resources available on the main PHP website, and there are many external resources discussing PHP programming and related topics.</p>
+		<p>One great feature of PHP as a community is the documentation. There are fantastic resources available on the main PHP website, and there are many external resources discussing PHP programming and related topics.</p>
 
-    <p>PHP provides integration with many other libraries, such as databases, image manipulation and network communication. However, each external library tends to have its own syntax and semantic behavior. This can make larger programs unmanageable without careful planning.</p>
+		<p>PHP provides integration with many other libraries, such as databases, image manipulation and network communication. However, each external library tends to have its own syntax and semantic behavior. This can make larger programs unmanageable without careful planning.</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://en.wikibooks.org/wiki/PHP_Programming">PHP Programming Wikibook</a></dt>
-      <dd>A comprehensive guide to learning to program using PHP.</dd>
-    </dl>
+		<dl class="resources">
+			<dt><a href="http://en.wikibooks.org/wiki/PHP_Programming">PHP Programming Wikibook</a></dt>
+			<dd>A comprehensive guide to learning to program using PHP.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/PHP">Wikipedia: PHP</a></li>
-      <li><a href="http://www.php.net/">PHP: Hypertext Preprocessor</a> (Main Website)</li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/PHP">Wikipedia: PHP</a></li>
+			<li><a href="http://www.php.net/">PHP: Hypertext Preprocessor</a> (Main Website)</li>
+		</ul>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzphp">here</a>.</p>
+		<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzphp">here</a>.</p>
 
-    <content:listing src="fizz-buzz-example.txt" brush="html" />
+		<content:listing src="fizz-buzz-example.txt" brush="html" />
 
-    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsphp">here</a>.</p>
+		<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsphp">here</a>.</p>
 
-    <content:listing src="100-doors-example.txt" brush="html" />
+		<content:listing src="100-doors-example.txt" brush="html" />
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/python/index.xnode
+++ b/pages/languages/python/index.xnode
@@ -1,44 +1,48 @@
 <content:page>
-  <content:heading>Python</content:heading>
+  <header>
+    <content:heading>Python</content:heading>
 
-  <p>Python (currently version 3) is a <content:tt>dynamically typed</content:tt> programming language with both <content:tt>imperative</content:tt> and <content:tt>functional</content:tt> features. Python source code is executed by the Python <content:tt to="interpreted">interpreter</content:tt> which internally <content:tt>compiles</content:tt> the code to bytecode for better performance.</p>
+    <p>Python (currently version 3) is a <content:tt>dynamically typed</content:tt> programming language with both <content:tt>imperative</content:tt> and <content:tt>functional</content:tt> features. Python source code is executed by the Python <content:tt to="interpreted">interpreter</content:tt> which internally <content:tt>compiles</content:tt> the code to bytecode for better performance.</p>
+  </header>
 
-  <h2>Why would I learn this language?</h2>
+  <main>
+    <h2>Why would I learn this language?</h2>
 
-  <p>Python has a very clean syntax and a well thought out design.</p>
+    <p>Python has a very clean syntax and a well thought out design.</p>
 
-  <p>It is used in many different areas of software engineering such as web programming, scientific and numerical computing, and comes with a large standard library. There are many third party libraries available too.</p>
+    <p>It is used in many different areas of software engineering such as web programming, scientific and numerical computing, and comes with a large standard library. There are many third party libraries available too.</p>
 
-  <p>Python is used by many large organizations in many <a href="http://www.python.org/about/success/">successful projects</a>.</p>
+    <p>Python is used by many large organizations in many <a href="http://www.python.org/about/success/">successful projects</a>.</p>
 
-  <h2>Starting Points</h2>
+    <h2>Starting Points</h2>
 
-  <dl class="resources">
-    <dt><a href="http://wiki.python.org/moin/BeginnersGuide">Beginner's Guide to Python</a></dt>
-    <dd>Learn to program using Python. A beginners guide which includes to links to many useful resources.</dd>
+    <dl class="resources">
+      <dt><a href="http://wiki.python.org/moin/BeginnersGuide">Beginner's Guide to Python</a></dt>
+      <dd>Learn to program using Python. A beginners guide which includes to links to many useful resources.</dd>
 
-    <dt><a href="http://davidbau.com/python/learning.html">Learning to Program with Python (version 2)</a></dt>
-    <dd>Learn to make a game of hangman from scratch.</dd>
-  </dl>
+      <dt><a href="http://davidbau.com/python/learning.html">Learning to Program with Python (version 2)</a></dt>
+      <dd>Learn to make a game of hangman from scratch.</dd>
+    </dl>
 
-  <h2>Further Reading</h2>
+    <h2>Further Reading</h2>
 
-  <ul>
-    <li><a href="http://en.wikipedia.org/wiki/Python_(programming_language)">Wikipedia: Python</a></li>
-    <li><a href="http://www.python.org/">Python</a> (Main Website)</li>
-    <li><a href="http://www.python.org/community/sigs/current/edu-sig/">Python in Education</a></li>
-    <li><a href="http://www.linuxjournal.com/article/3882">Why Python?</a></li>
-  </ul>
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/Python_(programming_language)">Wikipedia: Python</a></li>
+      <li><a href="http://www.python.org/">Python</a> (Main Website)</li>
+      <li><a href="http://www.python.org/community/sigs/current/edu-sig/">Python in Education</a></li>
+      <li><a href="http://www.linuxjournal.com/article/3882">Why Python?</a></li>
+    </ul>
 
-  <h2>Example Code</h2>
+    <h2>Example Code</h2>
 
-  <p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
+    <p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
 
-  <iframe height="600px" width="100%" src="https://repl.it/@programmingdojo/fizzbuzzpy?lite=true" frameborder="no"></iframe>
+    <iframe height="600px" width="100%" src="https://repl.it/@programmingdojo/fizzbuzzpy?lite=true" frameborder="no"></iframe>
 
-  <p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
+    <p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
 
-  <iframe height="600px" width="100%" src="https://repl.it/@programmingdojo/100doorspy?lite=true" frameborder="no"></iframe>
+    <iframe height="600px" width="100%" src="https://repl.it/@programmingdojo/100doorspy?lite=true" frameborder="no"></iframe>
 
-  <comments />
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/python/index.xnode
+++ b/pages/languages/python/index.xnode
@@ -1,54 +1,44 @@
 <content:page>
-    <div class="container">
-		<content:heading>Python</content:heading>
-		<p>Python (currently version 3) is a <content:tt>dynamically typed</content:tt> programming language with both <content:tt>imperative</content:tt> and <content:tt>functional</content:tt> features. Python source code is executed by the Python <content:tt to="interpreted">interpreter</content:tt> which internally <content:tt>compiles</content:tt> the code to bytecode for better performance.</p>
-		<div class="row align-items-center">
-			<div class="column">
-				<div class="subsection">
-					<h3>Why would I learn this language?</h3>
+  <content:heading>Python</content:heading>
 
-					<p>Python has a very clean syntax and a well thought out design.</p>
+  <p>Python (currently version 3) is a <content:tt>dynamically typed</content:tt> programming language with both <content:tt>imperative</content:tt> and <content:tt>functional</content:tt> features. Python source code is executed by the Python <content:tt to="interpreted">interpreter</content:tt> which internally <content:tt>compiles</content:tt> the code to bytecode for better performance.</p>
 
-					<p>It is used in many different areas of software engineering such as web programming, scientific and numerical computing, and comes with a large standard library. There are many third party libraries available too.</p>
+  <h2>Why would I learn this language?</h2>
 
-					<p>Python is used by many large organizations in many <a href="http://www.python.org/about/success/">successful projects</a>.</p>
-				</div>
-				<div class="subsection">
-					<h3>Starting Points</h3>
+  <p>Python has a very clean syntax and a well thought out design.</p>
 
-					<dl class="resources">
-						<dt><a href="http://wiki.python.org/moin/BeginnersGuide">Beginner's Guide to Python</a></dt>
-						<dd>Learn to program using Python. A beginners guide which includes to links to many useful resources.</dd>
+  <p>It is used in many different areas of software engineering such as web programming, scientific and numerical computing, and comes with a large standard library. There are many third party libraries available too.</p>
 
-						<dt><a href="http://davidbau.com/python/learning.html">Learning to Program with Python (version 2)</a></dt>
-						<dd>Learn to make a game of hangman from scratch.</dd>
-					</dl>
-				</div>
+  <p>Python is used by many large organizations in many <a href="http://www.python.org/about/success/">successful projects</a>.</p>
 
-				<div class="subsection">
-					<h3>Further Reading</h3>
+  <h2>Starting Points</h2>
 
-					<ul>
-						<li><a href="http://en.wikipedia.org/wiki/Python_(programming_language)">Wikipedia: Python</a></li>
-						<li><a href="http://www.python.org/">Python</a> (Main Website)</li>
-						<li><a href="http://www.python.org/community/sigs/current/edu-sig/">Python in Education</a></li>
-						<li><a href="http://www.linuxjournal.com/article/3882">Why Python?</a></li>
-					</ul>
-				</div>
-			</div>
+  <dl class="resources">
+    <dt><a href="http://wiki.python.org/moin/BeginnersGuide">Beginner's Guide to Python</a></dt>
+    <dd>Learn to program using Python. A beginners guide which includes to links to many useful resources.</dd>
 
-			<div class="column">
-				<h3>Example Code</h3>
+    <dt><a href="http://davidbau.com/python/learning.html">Learning to Program with Python (version 2)</a></dt>
+    <dd>Learn to make a game of hangman from scratch.</dd>
+  </dl>
 
-				<p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
+  <h2>Further Reading</h2>
 
-				<iframe height="600px" width="100%" src="https://repl.it/@programmingdojo/fizzbuzzpy?lite=true" frameborder="no"></iframe>
+  <ul>
+    <li><a href="http://en.wikipedia.org/wiki/Python_(programming_language)">Wikipedia: Python</a></li>
+    <li><a href="http://www.python.org/">Python</a> (Main Website)</li>
+    <li><a href="http://www.python.org/community/sigs/current/edu-sig/">Python in Education</a></li>
+    <li><a href="http://www.linuxjournal.com/article/3882">Why Python?</a></li>
+  </ul>
 
-				<p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
+  <h2>Example Code</h2>
 
-				<iframe height="600px" width="100%" src="https://repl.it/@programmingdojo/100doorspy?lite=true" frameborder="no"></iframe>
-			</div>
-		</div>
-	</div>
-	<comments />
+  <p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
+
+  <iframe height="600px" width="100%" src="https://repl.it/@programmingdojo/fizzbuzzpy?lite=true" frameborder="no"></iframe>
+
+  <p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
+
+  <iframe height="600px" width="100%" src="https://repl.it/@programmingdojo/100doorspy?lite=true" frameborder="no"></iframe>
+
+  <comments />
 </content:page>

--- a/pages/languages/python/index.xnode
+++ b/pages/languages/python/index.xnode
@@ -1,48 +1,48 @@
 <content:page>
-  <header>
-    <content:heading>Python</content:heading>
+	<header>
+		<content:heading>Python</content:heading>
 
-    <p>Python (currently version 3) is a <content:tt>dynamically typed</content:tt> programming language with both <content:tt>imperative</content:tt> and <content:tt>functional</content:tt> features. Python source code is executed by the Python <content:tt to="interpreted">interpreter</content:tt> which internally <content:tt>compiles</content:tt> the code to bytecode for better performance.</p>
-  </header>
+		<p>Python (currently version 3) is a <content:tt>dynamically typed</content:tt> programming language with both <content:tt>imperative</content:tt> and <content:tt>functional</content:tt> features. Python source code is executed by the Python <content:tt to="interpreted">interpreter</content:tt> which internally <content:tt>compiles</content:tt> the code to bytecode for better performance.</p>
+	</header>
 
-  <main>
-    <h2>Why would I learn this language?</h2>
+	<main>
+		<h2>Why would I learn this language?</h2>
 
-    <p>Python has a very clean syntax and a well thought out design.</p>
+		<p>Python has a very clean syntax and a well thought out design.</p>
 
-    <p>It is used in many different areas of software engineering such as web programming, scientific and numerical computing, and comes with a large standard library. There are many third party libraries available too.</p>
+		<p>It is used in many different areas of software engineering such as web programming, scientific and numerical computing, and comes with a large standard library. There are many third party libraries available too.</p>
 
-    <p>Python is used by many large organizations in many <a href="http://www.python.org/about/success/">successful projects</a>.</p>
+		<p>Python is used by many large organizations in many <a href="http://www.python.org/about/success/">successful projects</a>.</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://wiki.python.org/moin/BeginnersGuide">Beginner's Guide to Python</a></dt>
-      <dd>Learn to program using Python. A beginners guide which includes to links to many useful resources.</dd>
+		<dl class="resources">
+			<dt><a href="http://wiki.python.org/moin/BeginnersGuide">Beginner's Guide to Python</a></dt>
+			<dd>Learn to program using Python. A beginners guide which includes to links to many useful resources.</dd>
 
-      <dt><a href="http://davidbau.com/python/learning.html">Learning to Program with Python (version 2)</a></dt>
-      <dd>Learn to make a game of hangman from scratch.</dd>
-    </dl>
+			<dt><a href="http://davidbau.com/python/learning.html">Learning to Program with Python (version 2)</a></dt>
+			<dd>Learn to make a game of hangman from scratch.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/Python_(programming_language)">Wikipedia: Python</a></li>
-      <li><a href="http://www.python.org/">Python</a> (Main Website)</li>
-      <li><a href="http://www.python.org/community/sigs/current/edu-sig/">Python in Education</a></li>
-      <li><a href="http://www.linuxjournal.com/article/3882">Why Python?</a></li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/Python_(programming_language)">Wikipedia: Python</a></li>
+			<li><a href="http://www.python.org/">Python</a> (Main Website)</li>
+			<li><a href="http://www.python.org/community/sigs/current/edu-sig/">Python in Education</a></li>
+			<li><a href="http://www.linuxjournal.com/article/3882">Why Python?</a></li>
+		</ul>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
+		<p>Here is an example of the <content:tt>Fizz Buzz</content:tt> problem:</p>
 
-    <iframe height="600px" width="100%" src="https://repl.it/@programmingdojo/fizzbuzzpy?lite=true" frameborder="no"></iframe>
+		<iframe height="600px" width="100%" src="https://repl.it/@programmingdojo/fizzbuzzpy?lite=true" frameborder="no"></iframe>
 
-    <p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
+		<p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
 
-    <iframe height="600px" width="100%" src="https://repl.it/@programmingdojo/100doorspy?lite=true" frameborder="no"></iframe>
+		<iframe height="600px" width="100%" src="https://repl.it/@programmingdojo/100doorspy?lite=true" frameborder="no"></iframe>
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/ruby/index.xnode
+++ b/pages/languages/ruby/index.xnode
@@ -6,7 +6,7 @@
   </header>
 
   <main>
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>Ruby is a both powerful and easy to learn. It has a syntax which feels natural and is also very flexible.</p>
 
@@ -14,7 +14,7 @@
 
     <p>Ruby is a cross platform development language with multiple implementations, including MRI (the default implementation), <a href="http://www.jruby.org/">JRuby</a>, <a href="http://ironruby.net/">IronRuby</a> and <a href="http://rubini.us/">Rubinius</a>.</p>
 
-    <h3>Starting Points</h3>
+    <h2>Starting Points</h2>
 
     <dl class="resources">
       <dt><a href="http://tryruby.org/">Try Ruby</a></dt>
@@ -30,7 +30,7 @@
       <dd>A tutorial and reference for the Ruby programming language.</dd>
     </dl>
 
-    <h3>Further Reading</h3>
+    <h2>Further Reading</h2>
 
     <ul>
       <li><a href="http://en.wikipedia.org/wiki/Ruby_(programming_language)">Wikipedia: Ruby</a></li>
@@ -38,7 +38,7 @@
       <li><a href="http://www.rubyonrails.org/">Ruby on Rails</a></li>
     </ul>
 
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzrb">here</a>.</p>
 

--- a/pages/languages/ruby/index.xnode
+++ b/pages/languages/ruby/index.xnode
@@ -1,49 +1,53 @@
 <content:page>
-	<content:heading>Ruby</content:heading>
-	
-	<p>Ruby is a <content:tt>dynamically typed</content:tt> <content:tt>object oriented</content:tt> programming language with both <content:tt>imperative</content:tt> and <content:tt>functional</content:tt> features. Ruby code is often <content:tt>interpreted</content:tt> but several systems perform native code generation too.</p>
+  <header>
+    <content:heading>Ruby</content:heading>
 
-	<h3>Why would I learn this language?</h3>
-	
-	<p>Ruby is a both powerful and easy to learn. It has a syntax which feels natural and is also very flexible.</p>
-	
-	<p>Ruby is surrounded by a passionate community and there are a wide range of <a href="http://rubygems.org/">3rd party libraries available</a>. This makes it easy to develop new applications by relying on existing work.</p>
-	
-	<p>Ruby is a cross platform development language with multiple implementations, including MRI (the default implementation), <a href="http://www.jruby.org/">JRuby</a>, <a href="http://ironruby.net/">IronRuby</a> and <a href="http://rubini.us/">Rubinius</a>.</p>
-	
-	<h3>Starting Points</h3>
+    <p>Ruby is a <content:tt>dynamically typed</content:tt> <content:tt>object oriented</content:tt> programming language with both <content:tt>imperative</content:tt> and <content:tt>functional</content:tt> features. Ruby code is often <content:tt>interpreted</content:tt> but several systems perform native code generation too.</p>
+  </header>
 
-	<dl class="resources">
-		<dt><a href="http://tryruby.org/">Try Ruby</a></dt>
-		<dd>An online interactive tutorial.</dd>
-		
-		<dt><a href="http://pine.fm/LearnToProgram/">Learn to Program</a></dt>
-		<dd>A complete introduction for programming using Ruby including advice for students and teachers.</dd>
+  <main>
+    <h3>Why would I learn this language?</h3>
 
-		<dt><a href="http://mislav.uniqpath.com/poignant-guide/">The Poignant Guide to Ruby</a></dt>
-		<dd>A fun illustrated introduction to programming using Ruby</dd>
-		
-		<dt><a href="http://ruby-doc.org/docs/ProgrammingRuby/">Programming Ruby: The Pragmatic Programmer's Guide</a></dt>
-		<dd>A tutorial and reference for the Ruby programming language.</dd>
-	</dl>
-	
-	<h3>Further Reading</h3>
-	
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/Ruby_(programming_language)">Wikipedia: Ruby</a></li>
-		<li><a href="http://www.ruby-lang.org/">Ruby</a> (Main Website)</li>
-		<li><a href="http://www.rubyonrails.org/">Ruby on Rails</a></li>
-	</ul>
+    <p>Ruby is a both powerful and easy to learn. It has a syntax which feels natural and is also very flexible.</p>
 
-	<h3>Example Code</h3>
+    <p>Ruby is surrounded by a passionate community and there are a wide range of <a href="http://rubygems.org/">3rd party libraries available</a>. This makes it easy to develop new applications by relying on existing work.</p>
 
-	<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzrb">here</a>.</p>
+    <p>Ruby is a cross platform development language with multiple implementations, including MRI (the default implementation), <a href="http://www.jruby.org/">JRuby</a>, <a href="http://ironruby.net/">IronRuby</a> and <a href="http://rubini.us/">Rubinius</a>.</p>
 
-	<content:listing src="fizz-buzz-example.txt" brush="ruby" />
+    <h3>Starting Points</h3>
 
-	<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsrb">here</a>.</p>
+    <dl class="resources">
+      <dt><a href="http://tryruby.org/">Try Ruby</a></dt>
+      <dd>An online interactive tutorial.</dd>
 
-	<content:listing src="100-doors-example.txt" brush="ruby" />
+      <dt><a href="http://pine.fm/LearnToProgram/">Learn to Program</a></dt>
+      <dd>A complete introduction for programming using Ruby including advice for students and teachers.</dd>
 
-	<comments />
+      <dt><a href="http://mislav.uniqpath.com/poignant-guide/">The Poignant Guide to Ruby</a></dt>
+      <dd>A fun illustrated introduction to programming using Ruby</dd>
+
+      <dt><a href="http://ruby-doc.org/docs/ProgrammingRuby/">Programming Ruby: The Pragmatic Programmer's Guide</a></dt>
+      <dd>A tutorial and reference for the Ruby programming language.</dd>
+    </dl>
+
+    <h3>Further Reading</h3>
+
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/Ruby_(programming_language)">Wikipedia: Ruby</a></li>
+      <li><a href="http://www.ruby-lang.org/">Ruby</a> (Main Website)</li>
+      <li><a href="http://www.rubyonrails.org/">Ruby on Rails</a></li>
+    </ul>
+
+    <h3>Example Code</h3>
+
+    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzrb">here</a>.</p>
+
+    <content:listing src="fizz-buzz-example.txt" brush="ruby" />
+
+    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsrb">here</a>.</p>
+
+    <content:listing src="100-doors-example.txt" brush="ruby" />
+
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/ruby/index.xnode
+++ b/pages/languages/ruby/index.xnode
@@ -1,53 +1,53 @@
 <content:page>
-  <header>
-    <content:heading>Ruby</content:heading>
+	<header>
+		<content:heading>Ruby</content:heading>
 
-    <p>Ruby is a <content:tt>dynamically typed</content:tt> <content:tt>object oriented</content:tt> programming language with both <content:tt>imperative</content:tt> and <content:tt>functional</content:tt> features. Ruby code is often <content:tt>interpreted</content:tt> but several systems perform native code generation too.</p>
-  </header>
+		<p>Ruby is a <content:tt>dynamically typed</content:tt> <content:tt>object oriented</content:tt> programming language with both <content:tt>imperative</content:tt> and <content:tt>functional</content:tt> features. Ruby code is often <content:tt>interpreted</content:tt> but several systems perform native code generation too.</p>
+	</header>
 
-  <main>
-    <h2>Why would I learn this language?</h2>
+	<main>
+		<h2>Why would I learn this language?</h2>
 
-    <p>Ruby is a both powerful and easy to learn. It has a syntax which feels natural and is also very flexible.</p>
+		<p>Ruby is a both powerful and easy to learn. It has a syntax which feels natural and is also very flexible.</p>
 
-    <p>Ruby is surrounded by a passionate community and there are a wide range of <a href="http://rubygems.org/">3rd party libraries available</a>. This makes it easy to develop new applications by relying on existing work.</p>
+		<p>Ruby is surrounded by a passionate community and there are a wide range of <a href="http://rubygems.org/">3rd party libraries available</a>. This makes it easy to develop new applications by relying on existing work.</p>
 
-    <p>Ruby is a cross platform development language with multiple implementations, including MRI (the default implementation), <a href="http://www.jruby.org/">JRuby</a>, <a href="http://ironruby.net/">IronRuby</a> and <a href="http://rubini.us/">Rubinius</a>.</p>
+		<p>Ruby is a cross platform development language with multiple implementations, including MRI (the default implementation), <a href="http://www.jruby.org/">JRuby</a>, <a href="http://ironruby.net/">IronRuby</a> and <a href="http://rubini.us/">Rubinius</a>.</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://tryruby.org/">Try Ruby</a></dt>
-      <dd>An online interactive tutorial.</dd>
+		<dl class="resources">
+			<dt><a href="http://tryruby.org/">Try Ruby</a></dt>
+			<dd>An online interactive tutorial.</dd>
 
-      <dt><a href="http://pine.fm/LearnToProgram/">Learn to Program</a></dt>
-      <dd>A complete introduction for programming using Ruby including advice for students and teachers.</dd>
+			<dt><a href="http://pine.fm/LearnToProgram/">Learn to Program</a></dt>
+			<dd>A complete introduction for programming using Ruby including advice for students and teachers.</dd>
 
-      <dt><a href="http://mislav.uniqpath.com/poignant-guide/">The Poignant Guide to Ruby</a></dt>
-      <dd>A fun illustrated introduction to programming using Ruby</dd>
+			<dt><a href="http://mislav.uniqpath.com/poignant-guide/">The Poignant Guide to Ruby</a></dt>
+			<dd>A fun illustrated introduction to programming using Ruby</dd>
 
-      <dt><a href="http://ruby-doc.org/docs/ProgrammingRuby/">Programming Ruby: The Pragmatic Programmer's Guide</a></dt>
-      <dd>A tutorial and reference for the Ruby programming language.</dd>
-    </dl>
+			<dt><a href="http://ruby-doc.org/docs/ProgrammingRuby/">Programming Ruby: The Pragmatic Programmer's Guide</a></dt>
+			<dd>A tutorial and reference for the Ruby programming language.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/Ruby_(programming_language)">Wikipedia: Ruby</a></li>
-      <li><a href="http://www.ruby-lang.org/">Ruby</a> (Main Website)</li>
-      <li><a href="http://www.rubyonrails.org/">Ruby on Rails</a></li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/Ruby_(programming_language)">Wikipedia: Ruby</a></li>
+			<li><a href="http://www.ruby-lang.org/">Ruby</a> (Main Website)</li>
+			<li><a href="http://www.rubyonrails.org/">Ruby on Rails</a></li>
+		</ul>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzrb">here</a>.</p>
+		<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzrb">here</a>.</p>
 
-    <content:listing src="fizz-buzz-example.txt" brush="ruby" />
+		<content:listing src="fizz-buzz-example.txt" brush="ruby" />
 
-    <p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsrb">here</a>.</p>
+		<p>The following is an example of the <content:tt>100 doors</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/100doorsrb">here</a>.</p>
 
-    <content:listing src="100-doors-example.txt" brush="ruby" />
+		<content:listing src="100-doors-example.txt" brush="ruby" />
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/scheme/index.xnode
+++ b/pages/languages/scheme/index.xnode
@@ -8,11 +8,11 @@
   <main>
     <p>Scheme can be both <content:tt>compiled</content:tt> and <content:tt>interpreted</content:tt>.</p>
 
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>Scheme is a syntactically simple language with many interesting features such as homoiconicity. It provides a powerful environment for learning about algorithms and functional programming, and computer science concepts in general.</p>
 
-    <h3>Starting Points</h3>
+    <h2>Starting Points</h2>
 
     <dl class="resources">
       <dt><a href="http://www.schemers.org/Education/">Schemers.org: Education</a></dt>
@@ -31,7 +31,7 @@
       <dd>A complete beginners guide to programming with Scheme and designing programs.</dd>
     </dl>
 
-    <h3>Further Reading</h3>
+    <h2>Further Reading</h2>
 
     <ul>
       <li><a href="http://en.wikipedia.org/wiki/Scheme_(programming_language)">Wikipedia: Scheme</a></li>
@@ -40,7 +40,7 @@
       <li><a href="http://www.plai.org/">Programming Languages: Application and Interpretation</a></li>
     </ul>
 
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzscm">here</a>.</p>
 

--- a/pages/languages/scheme/index.xnode
+++ b/pages/languages/scheme/index.xnode
@@ -1,55 +1,59 @@
 <content:page>
-	<content:heading>Scheme</content:heading>
-	
-	<p>Scheme is one of the main dialects of <content:tt>LISP</content:tt> and is a <content:tt>dynamically typed</content:tt> impure <content:tt>functional</content:tt> programming language.</p>
-	
-	<p>Scheme can be both <content:tt>compiled</content:tt> and <content:tt>interpreted</content:tt>.</p>
+  <header>
+    <content:heading>Scheme</content:heading>
 
-	<h3>Why would I learn this language?</h3>
+    <p>Scheme is one of the main dialects of <content:tt>LISP</content:tt> and is a <content:tt>dynamically typed</content:tt> impure <content:tt>functional</content:tt> programming language.</p>
+  </header>
 
-	<p>Scheme is a syntactically simple language with many interesting features such as homoiconicity. It provides a powerful environment for learning about algorithms and functional programming, and computer science concepts in general.</p>
-	
-	<h3>Starting Points</h3>
+  <main>
+    <p>Scheme can be both <content:tt>compiled</content:tt> and <content:tt>interpreted</content:tt>.</p>
 
-	<dl class="resources">
-		<dt><a href="http://www.schemers.org/Education/">Schemers.org: Education</a></dt>
-		<dd>A set of resources for people interested in Scheme as a tool in education.</dd>
+    <h3>Why would I learn this language?</h3>
 
-		<dt><a href="http://www.crockford.com/javascript/scheme.html">Little Scheme</a></dt>
-		<dd>An online Scheme evaluator which can be used to run simple Scheme code.</dd>
+    <p>Scheme is a syntactically simple language with many interesting features such as homoiconicity. It provides a powerful environment for learning about algorithms and functional programming, and computer science concepts in general.</p>
 
-		<dt><a href="http://www.htdp.org/">How To Design Programs</a></dt>
-		<dd>A complete teaching guide and student resource for learning about computer programming and computer science.</dd>
+    <h3>Starting Points</h3>
 
-		<dt><a href="http://plt-scheme.org/">PLT Scheme</a></dt>
-		<dd>PLT Scheme is an entire software stack including IDE for developing Scheme programs.</dd>
+    <dl class="resources">
+      <dt><a href="http://www.schemers.org/Education/">Schemers.org: Education</a></dt>
+      <dd>A set of resources for people interested in Scheme as a tool in education.</dd>
 
-		<dt><a href="http://www.htdp.org/">How to Design Programs</a></dt>
-		<dd>A complete beginners guide to programming with Scheme and designing programs.</dd>
-	</dl>
-	
-	<h3>Further Reading</h3>
-	
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/Scheme_(programming_language)">Wikipedia: Scheme</a></li>
-		<li><a href="http://en.wikipedia.org/wiki/Homoiconicity">Wikipedia: Homoiconicity</a></li>
-		<li><a href="http://www.defmacro.org/ramblings/lisp.html">The Nature of Lisp</a></li>
-		<li><a href="http://www.plai.org/">Programming Languages: Application and Interpretation</a></li>
-	</ul>
+      <dt><a href="http://www.crockford.com/javascript/scheme.html">Little Scheme</a></dt>
+      <dd>An online Scheme evaluator which can be used to run simple Scheme code.</dd>
 
-	<h3>Example Code</h3>
+      <dt><a href="http://www.htdp.org/">How To Design Programs</a></dt>
+      <dd>A complete teaching guide and student resource for learning about computer programming and computer science.</dd>
 
-	<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzscm">here</a>.</p>
+      <dt><a href="http://plt-scheme.org/">PLT Scheme</a></dt>
+      <dd>PLT Scheme is an entire software stack including IDE for developing Scheme programs.</dd>
 
-	<content:listing src="fizz-buzz-example.txt" brush="lisp" />
-	
-	<p>Here is an example of the <content:tt>100 doors</content:tt> problem implemented using functional concepts:</p>
+      <dt><a href="http://www.htdp.org/">How to Design Programs</a></dt>
+      <dd>A complete beginners guide to programming with Scheme and designing programs.</dd>
+    </dl>
 
-	<content:listing src="100-doors-example-functional.txt" brush="lisp" />
+    <h3>Further Reading</h3>
 
-	<p>Here is an example of the <content:tt>100 doors</content:tt> problem implemented using imperative concepts:</p>
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/Scheme_(programming_language)">Wikipedia: Scheme</a></li>
+      <li><a href="http://en.wikipedia.org/wiki/Homoiconicity">Wikipedia: Homoiconicity</a></li>
+      <li><a href="http://www.defmacro.org/ramblings/lisp.html">The Nature of Lisp</a></li>
+      <li><a href="http://www.plai.org/">Programming Languages: Application and Interpretation</a></li>
+    </ul>
 
-	<content:listing src="100-doors-example-imperative.txt" brush="lisp" />
+    <h3>Example Code</h3>
 
-	<comments />
+    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzscm">here</a>.</p>
+
+    <content:listing src="fizz-buzz-example.txt" brush="lisp" />
+
+    <p>Here is an example of the <content:tt>100 doors</content:tt> problem implemented using functional concepts:</p>
+
+    <content:listing src="100-doors-example-functional.txt" brush="lisp" />
+
+    <p>Here is an example of the <content:tt>100 doors</content:tt> problem implemented using imperative concepts:</p>
+
+    <content:listing src="100-doors-example-imperative.txt" brush="lisp" />
+
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/scheme/index.xnode
+++ b/pages/languages/scheme/index.xnode
@@ -1,59 +1,59 @@
 <content:page>
-  <header>
-    <content:heading>Scheme</content:heading>
+	<header>
+		<content:heading>Scheme</content:heading>
 
-    <p>Scheme is one of the main dialects of <content:tt>LISP</content:tt> and is a <content:tt>dynamically typed</content:tt> impure <content:tt>functional</content:tt> programming language.</p>
-  </header>
+		<p>Scheme is one of the main dialects of <content:tt>LISP</content:tt> and is a <content:tt>dynamically typed</content:tt> impure <content:tt>functional</content:tt> programming language.</p>
+	</header>
 
-  <main>
-    <p>Scheme can be both <content:tt>compiled</content:tt> and <content:tt>interpreted</content:tt>.</p>
+	<main>
+		<p>Scheme can be both <content:tt>compiled</content:tt> and <content:tt>interpreted</content:tt>.</p>
 
-    <h2>Why would I learn this language?</h2>
+		<h2>Why would I learn this language?</h2>
 
-    <p>Scheme is a syntactically simple language with many interesting features such as homoiconicity. It provides a powerful environment for learning about algorithms and functional programming, and computer science concepts in general.</p>
+		<p>Scheme is a syntactically simple language with many interesting features such as homoiconicity. It provides a powerful environment for learning about algorithms and functional programming, and computer science concepts in general.</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://www.schemers.org/Education/">Schemers.org: Education</a></dt>
-      <dd>A set of resources for people interested in Scheme as a tool in education.</dd>
+		<dl class="resources">
+			<dt><a href="http://www.schemers.org/Education/">Schemers.org: Education</a></dt>
+			<dd>A set of resources for people interested in Scheme as a tool in education.</dd>
 
-      <dt><a href="http://www.crockford.com/javascript/scheme.html">Little Scheme</a></dt>
-      <dd>An online Scheme evaluator which can be used to run simple Scheme code.</dd>
+			<dt><a href="http://www.crockford.com/javascript/scheme.html">Little Scheme</a></dt>
+			<dd>An online Scheme evaluator which can be used to run simple Scheme code.</dd>
 
-      <dt><a href="http://www.htdp.org/">How To Design Programs</a></dt>
-      <dd>A complete teaching guide and student resource for learning about computer programming and computer science.</dd>
+			<dt><a href="http://www.htdp.org/">How To Design Programs</a></dt>
+			<dd>A complete teaching guide and student resource for learning about computer programming and computer science.</dd>
 
-      <dt><a href="http://plt-scheme.org/">PLT Scheme</a></dt>
-      <dd>PLT Scheme is an entire software stack including IDE for developing Scheme programs.</dd>
+			<dt><a href="http://plt-scheme.org/">PLT Scheme</a></dt>
+			<dd>PLT Scheme is an entire software stack including IDE for developing Scheme programs.</dd>
 
-      <dt><a href="http://www.htdp.org/">How to Design Programs</a></dt>
-      <dd>A complete beginners guide to programming with Scheme and designing programs.</dd>
-    </dl>
+			<dt><a href="http://www.htdp.org/">How to Design Programs</a></dt>
+			<dd>A complete beginners guide to programming with Scheme and designing programs.</dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/Scheme_(programming_language)">Wikipedia: Scheme</a></li>
-      <li><a href="http://en.wikipedia.org/wiki/Homoiconicity">Wikipedia: Homoiconicity</a></li>
-      <li><a href="http://www.defmacro.org/ramblings/lisp.html">The Nature of Lisp</a></li>
-      <li><a href="http://www.plai.org/">Programming Languages: Application and Interpretation</a></li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/Scheme_(programming_language)">Wikipedia: Scheme</a></li>
+			<li><a href="http://en.wikipedia.org/wiki/Homoiconicity">Wikipedia: Homoiconicity</a></li>
+			<li><a href="http://www.defmacro.org/ramblings/lisp.html">The Nature of Lisp</a></li>
+			<li><a href="http://www.plai.org/">Programming Languages: Application and Interpretation</a></li>
+		</ul>
 
-    <h2>Example Code</h2>
+		<h2>Example Code</h2>
 
-    <p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzscm">here</a>.</p>
+		<p>The following is an example of the <content:tt>Fizz Buzz</content:tt> problem. You can run and edit this program <a href="https://repl.it/@programmingdojo/fizzbuzzscm">here</a>.</p>
 
-    <content:listing src="fizz-buzz-example.txt" brush="lisp" />
+		<content:listing src="fizz-buzz-example.txt" brush="lisp" />
 
-    <p>Here is an example of the <content:tt>100 doors</content:tt> problem implemented using functional concepts:</p>
+		<p>Here is an example of the <content:tt>100 doors</content:tt> problem implemented using functional concepts:</p>
 
-    <content:listing src="100-doors-example-functional.txt" brush="lisp" />
+		<content:listing src="100-doors-example-functional.txt" brush="lisp" />
 
-    <p>Here is an example of the <content:tt>100 doors</content:tt> problem implemented using imperative concepts:</p>
+		<p>Here is an example of the <content:tt>100 doors</content:tt> problem implemented using imperative concepts:</p>
 
-    <content:listing src="100-doors-example-imperative.txt" brush="lisp" />
+		<content:listing src="100-doors-example-imperative.txt" brush="lisp" />
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/scratch/index.xnode
+++ b/pages/languages/scratch/index.xnode
@@ -1,42 +1,42 @@
 <content:page>
-  <header>
-    <content:heading>Scratch</content:heading>
+	<header>
+		<content:heading>Scratch</content:heading>
 
-    <p>Scratch is a graphical programming environment which allows for drag and drop program creation. Scrach provides basic set of <content:tt>imperative</content:tt> features along with support for a variety of different kinds of audio and visual media.</p>
-  </header>
+		<p>Scratch is a graphical programming environment which allows for drag and drop program creation. Scrach provides basic set of <content:tt>imperative</content:tt> features along with support for a variety of different kinds of audio and visual media.</p>
+	</header>
 
-  <main>
-    <h2>Example Code</h2>
+	<main>
+		<h2>Example Code</h2>
 
-    <p>Here is an example of the <content:tt>100 doors</content:tt> problem. You can download this program: <a href="Scratch - 100 Doors.zip">Scratch - 100 Doors.zip</a> and try it out.</p>
+		<p>Here is an example of the <content:tt>100 doors</content:tt> problem. You can download this program: <a href="Scratch - 100 Doors.zip">Scratch - 100 Doors.zip</a> and try it out.</p>
 
-    <div class="gallery">
-      <img src="example.png" />
-    </div>
+		<div class="gallery">
+			<img src="example.png" />
+		</div>
 
-    <h2>Why would I learn this language?</h2>
+		<h2>Why would I learn this language?</h2>
 
-    <p>Scratch is a great language for people who are not yet familiar with programming language syntax or structure. It provides a simple framework for exploring programming concepts.</p>
+		<p>Scratch is a great language for people who are not yet familiar with programming language syntax or structure. It provides a simple framework for exploring programming concepts.</p>
 
-    <h2>Starting Points</h2>
+		<h2>Starting Points</h2>
 
-    <dl class="resources">
-      <dt><a href="http://scratch.mit.edu/">Scratch Home Page</a></dt>
-      <dd>Create and share your own interactive stories, games, music and art!</dd>
+		<dl class="resources">
+			<dt><a href="http://scratch.mit.edu/">Scratch Home Page</a></dt>
+			<dd>Create and share your own interactive stories, games, music and art!</dd>
 
-      <dt><a href="http://wiki.scratch.mit.edu/wiki/Scratch_Wiki">Scratch Wiki</a></dt>
-      <dd>A wide variety of Scratch resources and information.</dd>
+			<dt><a href="http://wiki.scratch.mit.edu/wiki/Scratch_Wiki">Scratch Wiki</a></dt>
+			<dd>A wide variety of Scratch resources and information.</dd>
 
-      <dt><a href="Scratch - FizzBuzz.zip">FizzBuzz</a> in Scratch (<a href="FizzBuzz-example.png">Screenshot</a>)</dt>
-      <dd>As featured on the <a href="/resources/programming-language-posters">Programming Language Posters</a></dd>
-    </dl>
+			<dt><a href="Scratch - FizzBuzz.zip">FizzBuzz</a> in Scratch (<a href="FizzBuzz-example.png">Screenshot</a>)</dt>
+			<dd>As featured on the <a href="/resources/programming-language-posters">Programming Language Posters</a></dd>
+		</dl>
 
-    <h2>Further Reading</h2>
+		<h2>Further Reading</h2>
 
-    <ul>
-      <li><a href="http://en.wikipedia.org/wiki/Scratch_(programming_language)">Wikipedia: Scratch</a></li>
-    </ul>
+		<ul>
+			<li><a href="http://en.wikipedia.org/wiki/Scratch_(programming_language)">Wikipedia: Scratch</a></li>
+		</ul>
 
-    <content:comments />
-  </main>
+		<content:comments />
+	</main>
 </content:page>

--- a/pages/languages/scratch/index.xnode
+++ b/pages/languages/scratch/index.xnode
@@ -6,7 +6,7 @@
   </header>
 
   <main>
-    <h3>Example Code</h3>
+    <h2>Example Code</h2>
 
     <p>Here is an example of the <content:tt>100 doors</content:tt> problem. You can download this program: <a href="Scratch - 100 Doors.zip">Scratch - 100 Doors.zip</a> and try it out.</p>
 
@@ -14,7 +14,7 @@
       <img src="example.png" />
     </div>
 
-    <h3>Why would I learn this language?</h3>
+    <h2>Why would I learn this language?</h2>
 
     <p>Scratch is a great language for people who are not yet familiar with programming language syntax or structure. It provides a simple framework for exploring programming concepts.</p>
 

--- a/pages/languages/scratch/index.xnode
+++ b/pages/languages/scratch/index.xnode
@@ -1,38 +1,42 @@
 <content:page>
-	<content:heading>Scratch</content:heading>
-	
-	<p>Scratch is a graphical programming environment which allows for drag and drop program creation. Scrach provides basic set of <content:tt>imperative</content:tt> features along with support for a variety of different kinds of audio and visual media.</p>
-	
-	<h3>Example Code</h3>
-	
-	<p>Here is an example of the <content:tt>100 doors</content:tt> problem. You can download this program: <a href="Scratch - 100 Doors.zip">Scratch - 100 Doors.zip</a> and try it out.</p>
-	
-	<div class="gallery">
-		<img src="example.png" />
-	</div>
-	
-	<h3>Why would I learn this language?</h3>
-	
-	<p>Scratch is a great language for people who are not yet familiar with programming language syntax or structure. It provides a simple framework for exploring programming concepts.</p>
-	
-	<h2>Starting Points</h2>
+  <header>
+    <content:heading>Scratch</content:heading>
 
-	<dl class="resources">
-		<dt><a href="http://scratch.mit.edu/">Scratch Home Page</a></dt>
-		<dd>Create and share your own interactive stories, games, music and art!</dd>
-		
-		<dt><a href="http://wiki.scratch.mit.edu/wiki/Scratch_Wiki">Scratch Wiki</a></dt>
-		<dd>A wide variety of Scratch resources and information.</dd>
-		
-		<dt><a href="Scratch - FizzBuzz.zip">FizzBuzz</a> in Scratch (<a href="FizzBuzz-example.png">Screenshot</a>)</dt>
-		<dd>As featured on the <a href="/resources/programming-language-posters">Programming Language Posters</a></dd>
-	</dl>
-	
-	<h2>Further Reading</h2>
-	
-	<ul>
-		<li><a href="http://en.wikipedia.org/wiki/Scratch_(programming_language)">Wikipedia: Scratch</a></li>
-	</ul>
-	
-	<comments />
+    <p>Scratch is a graphical programming environment which allows for drag and drop program creation. Scrach provides basic set of <content:tt>imperative</content:tt> features along with support for a variety of different kinds of audio and visual media.</p>
+  </header>
+
+  <main>
+    <h3>Example Code</h3>
+
+    <p>Here is an example of the <content:tt>100 doors</content:tt> problem. You can download this program: <a href="Scratch - 100 Doors.zip">Scratch - 100 Doors.zip</a> and try it out.</p>
+
+    <div class="gallery">
+      <img src="example.png" />
+    </div>
+
+    <h3>Why would I learn this language?</h3>
+
+    <p>Scratch is a great language for people who are not yet familiar with programming language syntax or structure. It provides a simple framework for exploring programming concepts.</p>
+
+    <h2>Starting Points</h2>
+
+    <dl class="resources">
+      <dt><a href="http://scratch.mit.edu/">Scratch Home Page</a></dt>
+      <dd>Create and share your own interactive stories, games, music and art!</dd>
+
+      <dt><a href="http://wiki.scratch.mit.edu/wiki/Scratch_Wiki">Scratch Wiki</a></dt>
+      <dd>A wide variety of Scratch resources and information.</dd>
+
+      <dt><a href="Scratch - FizzBuzz.zip">FizzBuzz</a> in Scratch (<a href="FizzBuzz-example.png">Screenshot</a>)</dt>
+      <dd>As featured on the <a href="/resources/programming-language-posters">Programming Language Posters</a></dd>
+    </dl>
+
+    <h2>Further Reading</h2>
+
+    <ul>
+      <li><a href="http://en.wikipedia.org/wiki/Scratch_(programming_language)">Wikipedia: Scratch</a></li>
+    </ul>
+
+    <content:comments />
+  </main>
 </content:page>

--- a/pages/languages/smalltalk/index.xnode
+++ b/pages/languages/smalltalk/index.xnode
@@ -1,17 +1,17 @@
 <content:page>
 	<header>
 		<content:heading>Smalltalk</content:heading>
-	
+
 		<p>Smalltalk is a <content:tt>dynamically typed</content:tt> <content:tt>message passing</content:tt> language. It is unique due to syntax and <content:tt>object oriented</content:tt> features. It is generally <content:tt>interpreted</content:tt> but is often <content:tt>compiled</content:tt> to a bytecode first.</p>
 	</header>
-	
+
 	<main>
 		<h2>Why would I learn this language?</h2>
 
 		<p>Smalltalk is a powerful environment for exploring many different elements of computer programming, including rich media such as audio and user interfaces. Smalltalk code is generally concise and easily readable due to its message based syntax.</p>
-		
+
 		<p>Smalltalk provides an integrated code browser and debugger which are incredibly powerful and easy to use. This makes Smalltalk a highly productive environment where code can be modified and fixed in the running application.</p>
-		
+
 		<h2>Starting Points</h2>
 
 		<dl class="resources">
@@ -24,9 +24,9 @@
 			<dt><a href="http://wiki.squeak.org/squeak/377">Introduction to Squeak</a></dt>
 			<dd>A set of resources for learning about Smalltalk programming in the <a href="http://www.squeak.org/">Squeak</a> environment.</dd>
 		</dl>
-		
+
 		<h2>Further Reading</h2>
-		
+
 		<ul>
 			<li><a href="http://en.wikipedia.org/wiki/Smalltalk_(programming_language)">Wikipedia: Smalltalk</a></li>
 			<li><a href="http://www.smalltalk.org">Smalltalk</a> (Main Website)</li>
@@ -42,7 +42,7 @@
 		<p>Here is an example of the <content:tt>100 doors</content:tt> problem:</p>
 
 		<content:listing src="100-doors-example.txt" brush="smalltalk" />
-		
+
 		<content:comments />
 	</main>
 </content:page>


### PR DESCRIPTION
This PR is an attempt to fix #19.

There are a couple of points to note:

- I assumed that one `<p>` tag was supposed to be inside the `<header>` tag. The alternative would be that all the `<p>` tags up to the next `<h2>` tag should be inside the `<header>` tag.

- I assumed that only the language pages were to be updated. The alternative would be to update every page of the site.

- The language pages sometimes used `<h2>` and sometimes used `<h3>`. I updated them all to be `<h2>`.

- The Swift 'example' used `<content:comments />`. I updated all the other pages I changed to match.

- The Smalltalk page was already up to date. The only changes I made were to remove some trailing whitespace.

Let me know if any of the above was incorrect!