### PR TITLE
Fix menus on smaller devices

### DIFF
--- a/public/_static/site.css
+++ b/public/_static/site.css
@@ -334,7 +334,6 @@ nav a:hover {
 nav ul ul {
 	display: none;
 	position: absolute;
-	top: 40px;
 	z-index: 1;
 }
 	


### PR DESCRIPTION
After some investigating (on the inspector and my own mobile device) it appeared that only menus that were wrapped onto the second line were broken. This was actually the case for desktop as well (if the screen size was small enough).

Note that I haven't tested this fix on an actual touch device - just by using the browser inspector.

Resolves #22 (I hope).

![dojo2-4](https://user-images.githubusercontent.com/16066822/73227181-81d1b600-41d7-11ea-8c88-450415bd708c.gif)
